### PR TITLE
Standard bin size in histogram

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Martin Aspeli
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/jira_agile_metrics/calculators/histogram_test.py
+++ b/jira_agile_metrics/calculators/histogram_test.py
@@ -28,16 +28,16 @@ def test_empty(query_manager, settings, minimal_cycle_time_columns):
     data = calculator.run()
 
     assert list(data.index) == [
-        '0.0 to 0.1',
-        '0.1 to 0.2',
-        '0.2 to 0.3',
-        '0.3 to 0.4',
-        '0.4 to 0.5',
-        '0.5 to 0.6',
-        '0.6 to 0.7',
-        '0.7 to 0.8',
-        '0.8 to 0.9',
-        '0.9 to 1.0'
+        '0.0 to 1.0',
+        '1.0 to 2.0',
+        '2.0 to 3.0',
+        '3.0 to 4.0',
+        '4.0 to 5.0',
+        '5.0 to 6.0',
+        '6.0 to 7.0',
+        '7.0 to 8.0',
+        '8.0 to 9.0',
+        '9.0 to 10.0'
     ]
 
     assert list(data) == [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
@@ -48,15 +48,11 @@ def test_calculate_histogram(query_manager, settings, results):
     data = calculator.run()
 
     assert list(data.index) == [
-        '4.0 to 4.1',
-        '4.1 to 4.2',
-        '4.2 to 4.3',
-        '4.3 to 4.4',
-        '4.4 to 4.5',
-        '4.5 to 4.6',
-        '4.6 to 4.7',
-        '4.7 to 4.8',
-        '4.8 to 4.9',
-        '4.9 to 5.0'
+        '0.0 to 1.0',
+        '1.0 to 2.0',
+        '2.0 to 3.0',
+        '3.0 to 4.0',
+        '4.0 to 5.0',
+        '5.0 to 6.0'
     ]
-    assert list(data) == [1, 0, 0, 0, 0, 0, 0, 0, 0, 5]
+    assert list(data) == [0, 0, 0, 0, 1, 5]

--- a/jira_agile_metrics/calculators/waste.py
+++ b/jira_agile_metrics/calculators/waste.py
@@ -49,16 +49,16 @@ class WasteCalculator(Calculator):
             # Assume all waste items are resolved somehow
             if not issue.fields.resolution:
                 continue
-            
+
             last_status = None
             status_changes = list(self.query_manager.iter_changes(issue, ['status']))
             if len(status_changes) > 0:
                 last_status = status_changes[-1].from_string
-            
+
             if last_status is not None and last_status.lower() in cycle_lookup:
                 last_status = cycle_lookup.get(last_status.lower())['name']
             else:
-                logger.warn("Issue %s transitioned from unknown JIRA status %s", issue.key, last_status)
+                logger.warning("Issue %s transitioned from unknown JIRA status %s", issue.key, last_status)
 
             # Skip if last_status was the backlog or done column (not really withdrawn)
             if last_status in (backlog_column, done_column):
@@ -79,19 +79,19 @@ class WasteCalculator(Calculator):
         chart_data = self.get_result()
         if chart_data is None:
             return
-        
+
         output_file = self.settings['waste_chart']
         if not output_file:
             logger.debug("No output file specified for waste chart")
             return
-        
+
         if len(chart_data.index) == 0:
             logger.warning("Cannot draw waste chart with zero items")
             return
 
         frequency = self.settings['waste_frequency']
         window = self.settings['waste_window']
-        
+
         cycle_names = [s['name'] for s in self.settings['cycle']]
         backlog_column = self.settings['backlog_column']
         done_column = self.settings['done_column']
@@ -107,15 +107,15 @@ class WasteCalculator(Calculator):
 
         if window:
             breakdown = breakdown[-window:]
-        
+
         if len(breakdown.index) == 0 or len(breakdown.columns) == 0:
             logger.warning("Cannot draw waste chart with zero items")
             return
 
         fig, ax = plt.subplots()
-        
+
         breakdown.plot.bar(ax=ax, stacked=True)
-        
+
         if self.settings['waste_chart_title']:
             ax.set_title(self.settings['waste_chart_title'])
 

--- a/jira_agile_metrics/querymanager.py
+++ b/jira_agile_metrics/querymanager.py
@@ -14,7 +14,7 @@ class IssueSnapshot(object):
     def __init__(self, change, key, date, from_string, to_string):
         self.change = change
         self.key = key
-        self.date = date.astimezone(dateutil.tz.tzutc())
+        self.date = date
         self.from_string = from_string
         self.to_string = to_string
 
@@ -127,7 +127,7 @@ class QueryManager(object):
                 )).fromString
             except StopIteration:
                 pass
-            
+
             yield IssueSnapshot(
                 change=field,
                 key=issue.key,

--- a/jira_agile_metrics/utils.py
+++ b/jira_agile_metrics/utils.py
@@ -48,7 +48,7 @@ def breakdown_by_month(df, start_column, end_column, key_column, value_column, o
     each month broken down by each unique value in `value_column`. To restrict
     (and order) the value columns, pass a list of valid values as `output_columns`.
     """
-    
+
     def build_df(t):
         start_date = getattr(t, start_column)
         end_date = getattr(t, end_column)
@@ -62,18 +62,18 @@ def breakdown_by_month(df, start_column, end_column, key_column, value_column, o
         last_month = end_date.normalize().to_period('M').to_timestamp('D', 'S')
 
         index = pd.date_range(first_month, last_month, freq='MS')
-        
+
         return pd.DataFrame(
             index=index,
             data=[[key]],
             columns=[value]
         )
-    
-    breakdown = pd.concat([build_df(t) for t in df.itertuples()]).resample('MS').agg(aggfunc)
+
+    breakdown = pd.concat([build_df(t) for t in df.itertuples()], sort=True).resample('MS').agg(aggfunc)
 
     if output_columns:
         breakdown = breakdown[[s for s in output_columns if s in breakdown.columns]]
-    
+
     return breakdown
 
 def breakdown_by_month_sum_days(df, start_column, end_column, value_column, output_columns=None, aggfunc='sum'):
@@ -98,18 +98,18 @@ def breakdown_by_month_sum_days(df, start_column, end_column, value_column, outp
         last_month = end_date.normalize().to_period('M').to_timestamp('D', 'S')
 
         index = pd.date_range(first_month, last_month, freq='MS')
-        
+
         return pd.DataFrame(
             index=index,
             data=[[len(pd.date_range(month_start, month_start + pd.tseries.offsets.MonthEnd(1), freq='D').intersection(days_range))] for month_start in index],
             columns=[value]
         )
-    
-    breakdown = pd.concat([build_df(t) for t in df.itertuples()]).resample('MS').agg(aggfunc)
+
+    breakdown = pd.concat([build_df(t) for t in df.itertuples()], sort=True).resample('MS').agg(aggfunc)
 
     if output_columns:
         breakdown = breakdown[[s for s in output_columns if s in breakdown.columns]]
-    
+
     return breakdown
 
 def to_bin(value, edges):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,3 @@
 [aliases]
 test=pytest
+

--- a/setup.py
+++ b/setup.py
@@ -24,9 +24,8 @@ setup(
     keywords='agile jira analytics metrics',
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
     install_requires=install_requires,
-    tests_require=[
-        'pytest'
-    ],
+    setup_requires=['pytest-runner'],
+    tests_require=['pytest'],
     entry_points={
         'console_scripts': [
             'jira-agile-metrics=jira_agile_metrics.cli:main',


### PR DESCRIPTION
Hi Martin, I think the histogram is much easier to read if it uses a standard bin size of 1 day and if it displays the actual frequency instead of a normalised one. Before making the changes I had to fix the tests which were throwing some errors and warnings in my environment.

Let me know if you have questions.