### PR TITLE
Cycletime fix

### DIFF
--- a/jira_agile_metrics/calculators/cycletime.py
+++ b/jira_agile_metrics/calculators/cycletime.py
@@ -161,8 +161,10 @@ def calculate_cycle_times(
             impediment_start_status = None
             impediment_start = None
 
-            # Record date of status and impediments flag changes
-            for snapshot in query_manager.iter_changes(issue, ['status', 'Flagged']):
+            # Record date of status and impediments flag changes, order them by date
+            ordered_snapshots = list(query_manager.iter_changes(issue, ['status', 'Flagged']))
+            ordered_snapshots.sort(key=lambda x: x.date, reverse=False)
+            for snapshot in ordered_snapshots:
                 if snapshot.change == 'status':
                     snapshot_cycle_step = cycle_lookup.get(snapshot.to_string.lower(), None)
                     if snapshot_cycle_step is None:

--- a/jira_agile_metrics/calculators/progressreport.py
+++ b/jira_agile_metrics/calculators/progressreport.py
@@ -58,6 +58,7 @@ class ProgressReportCalculator(Calculator):
         epic_query_template = self.settings['progress_report_epic_query_template']
         if not epic_query_template:
             if (
+                self.settings['progress_report_outcomes'] is None or
                 len(self.settings['progress_report_outcomes']) == 0 or
                 any(map(lambda o: o['epic_query'] is None, self.settings['progress_report_outcomes']))
             ):


### PR DESCRIPTION
When calculating the cycle-time, ensure that the events are iterated in from the oldest to the newest one. The order matters as the cycle time and backwards movement detection is dependent on the order the transitions were performed.

Small fix for the case on which no progress report is specified.