### PR TITLE
Input parameter to decide whether or not to perform the JIRA server info check

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ above:
     # How to connect to JIRA. Can also include `Username` and `Password`
     Connection:
         Domain: https://myjira.atlassian.net # your JIRA instance
+        # bypass JIRA API call for the server version endpoint 
+    #   Jira server version check: False
 
     # What issues to search for. Uses JQL syntax.
     Query: Project=ABC AND IssueType=Story AND (Resolution IS NULL OR Resolution IN (Completed, Withdrawn))

--- a/jira_agile_metrics/cli.py
+++ b/jira_agile_metrics/cli.py
@@ -17,7 +17,7 @@ def configure_argument_parser():
     """Configure an ArgumentParser that manages command line options.
     """
 
-    parser = argparse.ArgumentParser(description='Extract Agile metrics data from JIRA and produce data and charts.')
+    parser = argparse.ArgumentParser(description='Extracting Agile metrics data from JIRA and produce data and charts.')
 
     # Basic options
     parser.add_argument('config', metavar='config.yml', nargs='?', help='Configuration file')
@@ -36,7 +36,8 @@ def configure_argument_parser():
     parser.add_argument('--password', metavar='password', help='JIRA password')
     parser.add_argument('--http-proxy', metavar='https://proxy.local', help='URL to HTTP Proxy')
     parser.add_argument('--https-proxy', metavar='https://proxy.local', help='URL to HTTPS Proxy')
-
+    parser.add_argument('--jira-server-version-check', type=bool, metavar='True', help='If true it will fetch JIRA server version info first to determine if some API calls are available')
+    
     return parser
 
 def main():
@@ -114,6 +115,8 @@ def get_jira_client(connection):
     password = connection['password']
     http_proxy = connection['http_proxy']
     https_proxy = connection['https_proxy']
+    jira_server_version_check = connection['jira_server_version_check']
+    logger.debug("Cheking JIRA server version: %s", jira_server_version_check)
 
     jira_client_options = connection['jira_client_options']
 
@@ -137,4 +140,4 @@ def get_jira_client(connection):
 
     options.update(jira_client_options)
 
-    return JIRA(options, basic_auth=(username, password), proxies=proxies)
+    return JIRA(options, basic_auth=(username, password), proxies=proxies, get_server_info=jira_server_version_check)

--- a/jira_agile_metrics/cli.py
+++ b/jira_agile_metrics/cli.py
@@ -17,7 +17,7 @@ def configure_argument_parser():
     """Configure an ArgumentParser that manages command line options.
     """
 
-    parser = argparse.ArgumentParser(description='Extracting Agile metrics data from JIRA and produce data and charts.')
+    parser = argparse.ArgumentParser(description='Extract Agile metrics data from JIRA and produce data and charts.')
 
     # Basic options
     parser.add_argument('config', metavar='config.yml', nargs='?', help='Configuration file')
@@ -116,7 +116,6 @@ def get_jira_client(connection):
     http_proxy = connection['http_proxy']
     https_proxy = connection['https_proxy']
     jira_server_version_check = connection['jira_server_version_check']
-    logger.debug("Cheking JIRA server version: %s", jira_server_version_check)
 
     jira_client_options = connection['jira_client_options']
 

--- a/jira_agile_metrics/config.py
+++ b/jira_agile_metrics/config.py
@@ -122,6 +122,7 @@ def config_to_options(data, cwd=None, extended=False):
             'password': None,
             'http_proxy': None,
             'https_proxy': None,
+            'jira_server_version_check': True,
             'jira_client_options': {}
         },
         'settings': {
@@ -285,6 +286,9 @@ def config_to_options(data, cwd=None, extended=False):
 
         if 'jira client options' in config['connection']:
             options['connection']['jira_client_options'] = config['connection']['jira client options']
+
+        if 'jira server version check' in config['connection']:
+            options['connection']['jira_server_version_check'] = config['connection']['jira server version check']
 
     # Parse and validate output options
     if 'output' in config:

--- a/jira_agile_metrics/config_test.py
+++ b/jira_agile_metrics/config_test.py
@@ -234,6 +234,7 @@ Output:
         'username': 'user1',
         'http_proxy': 'https://proxy1.local',
         'https_proxy': 'https://proxy2.local',
+        'jira_server_version_check': True
     }
    
     assert options['settings'] == {
@@ -552,3 +553,22 @@ Output:
             assert True
         else:
             assert False
+
+def test_config_to_options_jira_server_bypass():
+
+    options = config_to_options("""\
+Connection:
+    Domain: https://foo.com
+    JIRA server version check: False
+
+Query: (filter=123)
+
+Workflow:
+    Backlog: Backlog
+    In progress: Build
+    Done: Done
+""")
+
+    assert options['connection']['domain'] == 'https://foo.com'
+    assert options['connection']['jira_server_version_check'] == False
+

--- a/jira_agile_metrics/webapp/app.py
+++ b/jira_agile_metrics/webapp/app.py
@@ -113,12 +113,13 @@ def get_jira_client(connection):
     username = connection['username']
     password = connection['password']
     jira_client_options = connection['jira_client_options']
+    jira_server_version_check = connection['jira_server_version_check']
 
     jira_options = {'server': url}
     jira_options.update(jira_client_options)
 
     try:
-        return JIRA(jira_options, basic_auth=(username, password))
+        return JIRA(jira_options, basic_auth=(username, password), get_server_info=jira_server_version_check)
     except Exception as e:
         if e.status_code == 401:
             raise ConfigError("JIRA authentication failed. Check URL and credentials, and ensure the account is not locked.") from None

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(path.join(here, 'requirements.txt')) as f:
 
 setup(
     name='jira-agile-metrics',
-    version='0.24',
+    version='0.25',
     description='Agile metrics and summary data extracted from JIRA',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This is addressing https://github.com/DeloitteDigitalUK/jira-agile-metrics/issues/14

The JIRA server may return 403 while creating the JIRA object. This may due to security restrictions on the server. I recreated the issue, see logs below:

[2019-12-19 17:07:14 DEBUG] Starting new HTTPS connection (1): my.jira.com:443
[2019-12-19 17:07:14 DEBUG] https://my.jira.com:443 "GET /rest/api/2/serverInfo HTTP/1.1" 403 None

The new flag jira-server-version-check will skip the serverInfo check. By default, this check is always performed