### PR TITLE
Sort changelog histories so we get the initial value

### DIFF
--- a/jira_agile_metrics/querymanager.py
+++ b/jira_agile_metrics/querymanager.py
@@ -138,7 +138,8 @@ class QueryManager(object):
             try:
                 initial_value = next(filter(
                     lambda h: h.field == field,
-                    itertools.chain.from_iterable([c.items for c in issue.changelog.histories])
+                    itertools.chain.from_iterable([c.items for c in sorted(
+                        issue.changelog.histories, key=lambda c: dateutil.parser.parse(c.created))])
                 )).fromString
             except StopIteration:
                 pass

--- a/jira_agile_metrics/querymanager_test.py
+++ b/jira_agile_metrics/querymanager_test.py
@@ -24,9 +24,9 @@ def jira(custom_fields):
             customfield_002=Value(None, 30),
             customfield_003=Value(None, ["R2", "R3", "R4"]),
             changes=[
+                Change("2018-01-03 01:01:01", [("resolution", None, "Closed",), ("status", "Next", "Done",)]),
                 Change("2018-01-02 01:01:01", [("status", "Backlog", "Next",)]),
                 Change("2018-01-02 01:01:01", [("Team", "Team 2", "Team 1",)]),
-                Change("2018-01-03 01:01:01", [("resolution", None, "Closed",), ("status", "Next", "Done",)]),
                 Change("2018-01-04 01:01:01", [("resolution", "Closed", None,), ("status", "Done", "QA",)]),
             ],
         )

--- a/jira_agile_metrics/querymanager_test.py
+++ b/jira_agile_metrics/querymanager_test.py
@@ -24,6 +24,9 @@ def jira(custom_fields):
             customfield_002=Value(None, 30),
             customfield_003=Value(None, ["R2", "R3", "R4"]),
             changes=[
+                # the changes are not in chrnological order, the first change is intentionally the third 
+                # status change. This is intended to test that we manage get the correct first status change as
+                # the transition from Backlog to Next
                 Change("2018-01-03 01:01:01", [("resolution", None, "Closed",), ("status", "Next", "Done",)]),
                 Change("2018-01-02 01:01:01", [("status", "Backlog", "Next",)]),
                 Change("2018-01-02 01:01:01", [("Team", "Team 2", "Team 1",)]),


### PR DESCRIPTION
This handles the case where histories are not sorted by date from Jira.