### PR TITLE
Add support for skipped columns

### DIFF
--- a/jira_agile_metrics/calculators/ageingwip_test.py
+++ b/jira_agile_metrics/calculators/ageingwip_test.py
@@ -59,6 +59,17 @@ def jira_with_skipped_columns(minimal_fields):
                 Change("2018-01-02 08:15:00", [("status", "Backlog", "Done",), ("resolution", None, "Withdrawn")]), # skipping columns Committed, Build and Test
             ],
         ),
+        Issue("A-16",
+            summary="Gap in first committed step",
+            issuetype=Value("Story", "story"),
+            status=Value("Build", "Build"),
+            resolution=None,
+            resolutiondate=None,
+            created="2018-01-01 08:15:00",
+            changes=[
+                Change("2018-01-03 08:15:00", [("status", "Backlog", "Build",)]), # skipping column Committed
+            ],
+        ),
     ])
 
 @pytest.fixture
@@ -162,4 +173,5 @@ def test_calculate_ageing_wip_with_skipped_columns(jira_with_skipped_columns, se
     assert data[['key', 'status', 'age']].to_dict('records') == [
         {'key': 'A-13', 'status': 'Build', 'age': 8.0},
         {'key': 'A-14', 'status': 'Build', 'age': 8.0},
+        {'key': 'A-16', 'status': 'Build', 'age': 7.0},
     ]

--- a/jira_agile_metrics/calculators/ageingwip_test.py
+++ b/jira_agile_metrics/calculators/ageingwip_test.py
@@ -2,16 +2,64 @@ import pytest
 import datetime
 from pandas import DataFrame
 
+from ..conftest import (
+    FauxJIRA as JIRA,
+    FauxIssue as Issue,
+    FauxChange as Change,
+    FauxFieldValue as Value
+)
+
+from ..querymanager import QueryManager
 from .cycletime import CycleTimeCalculator
 from .ageingwip import AgeingWIPChartCalculator
 
 from ..utils import extend_dict
+
 
 @pytest.fixture
 def settings(minimal_settings):
     return extend_dict(minimal_settings, {
         'ageing_wip_chart': 'ageingwip.png'  # without a file to write the calculator will stop
     })
+
+@pytest.fixture
+def jira_with_skipped_columns(minimal_fields):
+    return JIRA(fields=minimal_fields, issues=[
+        Issue("A-13",
+            summary="No Gaps",
+            issuetype=Value("Story", "story"),
+            status=Value("Build", "build"),
+            resolution=None,
+            resolutiondate=None,
+            created="2018-01-01 08:15:00",
+            changes=[
+                Change("2018-01-02 08:15:00", [("status", "Backlog", "Next",)]),
+                Change("2018-01-03 08:15:00", [("status", "Next", "Build",)]),
+            ],
+        ),
+        Issue("A-14",
+            summary="Gaps",
+            issuetype=Value("Story", "story"),
+            status=Value("Build", "build"),
+            resolution=None,
+            resolutiondate=None,
+            created="2018-01-01 08:15:00",
+            changes=[
+                Change("2018-01-02 08:15:00", [("status", "Backlog", "Build",)]), # skipping column Committed
+            ],
+        ),
+        Issue("A-15",
+            summary="Gaps and withdrawn",
+            issuetype=Value("Story", "story"),
+            status=Value("Done", "done"),
+            resolution=Value("Withdrawn", "withdrawn"),
+            resolutiondate="2018-01-02 08:15:00",
+            created="2018-01-01 08:15:00",
+            changes=[
+                Change("2018-01-02 08:15:00", [("status", "Backlog", "Done",), ("resolution", None, "Withdrawn")]), # skipping columns Committed, Build and Test
+            ],
+        ),
+    ])
 
 @pytest.fixture
 def query_manager(minimal_query_manager):
@@ -21,9 +69,16 @@ def query_manager(minimal_query_manager):
 def results(large_cycle_time_results):
     return extend_dict(large_cycle_time_results, {})
 
+
+
 @pytest.fixture
 def today():
     return datetime.date(2018, 1, 10)
+
+@pytest.fixture
+def now(today):
+    return datetime.datetime.combine(today, datetime.time(8, 30, 00))
+
 
 def test_empty(query_manager, settings, minimal_cycle_time_columns, today):
     results = {
@@ -95,4 +150,17 @@ def test_calculate_ageing_wip_with_different_columns(query_manager, settings, re
         {'key': 'A-7', 'status': 'Build', 'age': 8.0},
         {'key': 'A-8', 'status': 'Build', 'age': 8.0},
         {'key': 'A-9', 'status': 'Build', 'age': 8.0}
+    ]
+
+def test_calculate_ageing_wip_with_skipped_columns(jira_with_skipped_columns, settings, today, now):
+    query_manager = QueryManager(jira_with_skipped_columns, settings)
+    results = {}
+    cycle_time_calc = CycleTimeCalculator(query_manager, settings, results)
+    results[CycleTimeCalculator] = cycle_time_calc.run(now=now)
+    ageing_wip_calc = AgeingWIPChartCalculator(query_manager, settings, results)
+    data = ageing_wip_calc.run(today=today)
+
+    assert data[['key', 'status', 'age']].to_dict('records') == [
+        {'key': 'A-13', 'status': 'Build', 'age': 8.0},
+        {'key': 'A-14', 'status': 'Build', 'age': 8.0},
     ]

--- a/jira_agile_metrics/calculators/ageingwip_test.py
+++ b/jira_agile_metrics/calculators/ageingwip_test.py
@@ -135,7 +135,6 @@ def test_calculate_ageing_wip(query_manager, settings, results, today):
 def test_calculate_ageing_wip_with_different_columns(query_manager, settings, results, today):
     settings.update({
         'committed_column': 'Committed',
-        'final_column': 'Build',
         'done_column': 'Test',
     })
 

--- a/jira_agile_metrics/calculators/burnup.py
+++ b/jira_agile_metrics/calculators/burnup.py
@@ -15,19 +15,12 @@ class BurnupCalculator(Calculator):
 
     def run(self):
         cfd_data = self.get_result(CFDCalculator)
-        
-        backlog_column = self.settings['backlog_column']
+
+        committed_column = self.settings['committed_column']
         done_column = self.settings['done_column']
 
-        if backlog_column not in cfd_data.columns:
-            logger.error("Backlog column %s does not exist", backlog_column)
-            return None
-        if done_column not in cfd_data.columns:
-            logger.error("Done column %s does not exist", done_column)
-            return None
+        return cfd_data[[committed_column, done_column]]
 
-        return cfd_data[[backlog_column, done_column]]
-    
     def write(self):
         output_file = self.settings['burnup_chart']
         if not output_file:
@@ -39,7 +32,7 @@ class BurnupCalculator(Calculator):
         if len(chart_data.index) == 0:
             logger.warning("Unable to draw burnup chart with no data items")
             return
-        
+
         window = self.settings['burnup_window']
         if window:
             start = chart_data.index.max() - pd.Timedelta(window, 'D')
@@ -51,7 +44,7 @@ class BurnupCalculator(Calculator):
                 return
 
         fig, ax = plt.subplots()
-        
+
         if self.settings['burnup_chart_title']:
             ax.set_title(self.settings['burnup_chart_title'])
 
@@ -65,7 +58,7 @@ class BurnupCalculator(Calculator):
         bottom = chart_data[chart_data.columns[-1]].min()
         top = chart_data[chart_data.columns[0]].max()
         ax.set_ylim(bottom=bottom, top=top)
-        
+
         # Place legend underneath graph
         box = ax.get_position()
         handles, labels = ax.get_legend_handles_labels()

--- a/jira_agile_metrics/calculators/burnup.py
+++ b/jira_agile_metrics/calculators/burnup.py
@@ -16,10 +16,10 @@ class BurnupCalculator(Calculator):
     def run(self):
         cfd_data = self.get_result(CFDCalculator)
 
-        committed_column = self.settings['committed_column']
+        backlog_column = self.settings['backlog_column']
         done_column = self.settings['done_column']
 
-        return cfd_data[[committed_column, done_column]]
+        return cfd_data[[backlog_column, done_column]]
 
     def write(self):
         output_file = self.settings['burnup_chart']

--- a/jira_agile_metrics/calculators/burnup_test.py
+++ b/jira_agile_metrics/calculators/burnup_test.py
@@ -35,14 +35,14 @@ def test_columns(query_manager, settings, results):
     data = calculator.run()
 
     assert list(data.columns) == [
-        'Committed',
+        'Backlog',
         'Done'
     ]
 
 def test_calculate_burnup(query_manager, settings, results):
     # beware: updating the settings here will circumvent the checks when loading the config
     settings.update({
-        'committed_column': 'Backlog'
+        'backlog_column': 'Backlog'
     })
 
     calculator = BurnupCalculator(query_manager, settings, results)
@@ -69,7 +69,7 @@ def test_calculate_burnup(query_manager, settings, results):
 
 def test_calculate_burnup_with_different_columns(query_manager, settings, results):
     settings.update({
-        'committed_column': 'Committed',
+        'backlog_column': 'Committed',
         'done_column': 'Test'
     })
 

--- a/jira_agile_metrics/calculators/burnup_test.py
+++ b/jira_agile_metrics/calculators/burnup_test.py
@@ -35,11 +35,16 @@ def test_columns(query_manager, settings, results):
     data = calculator.run()
 
     assert list(data.columns) == [
-        'Backlog',
+        'Committed',
         'Done'
     ]
 
 def test_calculate_burnup(query_manager, settings, results):
+    # beware: updating the settings here will circumvent the checks when loading the config
+    settings.update({
+        'committed_column': 'Backlog'
+    })
+
     calculator = BurnupCalculator(query_manager, settings, results)
 
     data = calculator.run()
@@ -64,7 +69,7 @@ def test_calculate_burnup(query_manager, settings, results):
 
 def test_calculate_burnup_with_different_columns(query_manager, settings, results):
     settings.update({
-        'backlog_column': 'Committed',
+        'committed_column': 'Committed',
         'done_column': 'Test'
     })
 

--- a/jira_agile_metrics/calculators/cfd.py
+++ b/jira_agile_metrics/calculators/cfd.py
@@ -27,7 +27,7 @@ class CFDCalculator(Calculator):
         cycle_names = [s['name'] for s in self.settings['cycle']]
 
         return calculate_cfd_data(cycle_data, cycle_names)
-    
+
     def write(self):
         data = self.get_result()
 
@@ -35,7 +35,7 @@ class CFDCalculator(Calculator):
             self.write_file(data, self.settings['cfd_data'])
         else:
             logger.debug("No output file specified for CFD file")
-        
+
         if self.settings['cfd_chart']:
             self.write_chart(data, self.settings['cfd_chart'])
         else:
@@ -52,24 +52,24 @@ class CFDCalculator(Calculator):
                 data.to_excel(output_file, 'CFD')
             else:
                 data.to_csv(output_file)
-    
+
     def write_chart(self, data, output_file):
         if len(data.index) == 0:
             logger.warning("Cannot draw CFD with no data")
             return
-        
+
         window = self.settings['cfd_window']
         if window:
             start = data.index.max() - pd.Timedelta(window, 'D')
             data = data[start:]
-        
+
             # Re-check after slicing
             if len(data.index) == 0:
                 logger.warning("Cannot draw CFD with no data")
                 return
 
         fig, ax = plt.subplots()
-        
+
         if self.settings['cfd_chart_title']:
             ax.set_title(self.settings['cfd_chart_title'])
 
@@ -79,11 +79,6 @@ class CFDCalculator(Calculator):
         ax.set_ylabel("Number of items")
 
         backlog_column = self.settings['backlog_column']
-
-        if backlog_column not in data.columns:
-            logger.error("Backlog column %s does not exist", backlog_column)
-            return None
-
         data = data.drop([backlog_column], axis=1)
         data.plot.area(ax=ax, stacked=False, legend=False)
 

--- a/jira_agile_metrics/calculators/cycletime.py
+++ b/jira_agile_metrics/calculators/cycletime.py
@@ -43,7 +43,7 @@ class CycleTimeCalculator(Calculator):
             self.query_manager,
             self.settings['cycle'],
             self.settings['attributes'],
-            self.settings['backlog_column'],
+            self.settings['committed_column'],
             self.settings['done_column'],
             self.settings['queries'],
             self.settings['query_attribute'],
@@ -52,7 +52,7 @@ class CycleTimeCalculator(Calculator):
 
     def write(self):
         output_files = self.settings['cycle_time_data']
-        
+
         if not output_files:
             logger.debug("No output file specified for cycle time data")
             return
@@ -83,7 +83,7 @@ def calculate_cycle_times(
     query_manager,
     cycle,                  # [{name:"", statuses:[""], type:""}]
     attributes,             # [{key:value}]
-    backlog_column,         # "" in `cycle`
+    committed_column,       # "" in `cycle`
     done_column,            # "" in `cycle`
     queries,                # [{jql:"", value:""}]
     query_attribute=None,   # ""
@@ -95,8 +95,7 @@ def calculate_cycle_times(
         now = datetime.datetime.utcnow()
 
     cycle_names = [s['name'] for s in cycle]
-    accepted_steps = set(s['name'] for s in cycle if s['type'] == StatusTypes.accepted)
-    completed_steps = set(s['name'] for s in cycle if s['type'] == StatusTypes.complete)
+    active_columns = cycle_names[cycle_names.index(committed_column):cycle_names.index(done_column)]
 
     cycle_lookup = {}
     for idx, cycle_step in enumerate(cycle):
@@ -104,7 +103,6 @@ def calculate_cycle_times(
             cycle_lookup[status.lower()] = dict(
                 index=idx,
                 name=cycle_step['name'],
-                type=cycle_step['type'],
             )
 
     unmapped_statuses = set()
@@ -169,7 +167,7 @@ def calculate_cycle_times(
                         logger.info("Issue %s transitioned to unknown JIRA status %s", issue.key, snapshot.to_string)
                         unmapped_statuses.add(snapshot.to_string)
                         continue
-                    
+
                     last_status = snapshot_cycle_step_name = snapshot_cycle_step['name']
 
                     # Keep the first time we entered a step
@@ -197,8 +195,8 @@ def calculate_cycle_times(
                         if impediment_start is None:
                             logger.warning("Issue %s had impediment flag cleared before being set. This should not happen.", issue.key)
                             continue
-                        
-                        if impediment_start_status not in (backlog_column, done_column):
+
+                        if impediment_start_status in active_columns:
                             item['blocked_days'] += (snapshot.date.date() - impediment_start).days
                         item['impediments'].append({
                             'start': impediment_start,
@@ -211,13 +209,13 @@ def calculate_cycle_times(
                         impediment_flag = None
                         impediment_start = None
                         impediment_start_status = None
-            
+
             # If an impediment flag was set but never cleared: treat as resolved on the ticket
             # resolution date if the ticket was resolved, else as still open until today.
             if impediment_start is not None:
                 if issue.fields.resolutiondate:
                     resolution_date = dateutil.parser.parse(issue.fields.resolutiondate).date()
-                    if impediment_start_status not in (backlog_column, done_column):
+                    if impediment_start_status in active_columns:
                         item['blocked_days'] += (resolution_date - impediment_start).days
                     item['impediments'].append({
                         'start': impediment_start,
@@ -226,7 +224,7 @@ def calculate_cycle_times(
                         'flag': impediment_flag,
                     })
                 else:
-                    if impediment_start_status not in (backlog_column, done_column):
+                    if impediment_start_status in active_columns:
                         item['blocked_days'] += (now.date() - impediment_start).days
                     item['impediments'].append({
                         'start': impediment_start,
@@ -237,25 +235,28 @@ def calculate_cycle_times(
                 impediment_flag = None
                 impediment_start = None
                 impediment_start_status = None
-            
-            # Wipe timestamps if items have moved backwards; calculate cycle time
+
+            # calculate cycle time
 
             previous_timestamp = None
-            accepted_timestamp = None
-            completed_timestamp = None
+            committed_timestamp = None
+            done_timestamp = None
 
-            for cycle_name in cycle_names:
+            for cycle_name in reversed(cycle_names):
                 if item[cycle_name] is not None:
                     previous_timestamp = item[cycle_name]
 
-                    if accepted_timestamp is None and previous_timestamp is not None and cycle_name in accepted_steps:
-                        accepted_timestamp = previous_timestamp
-                    if completed_timestamp is None and previous_timestamp is not None and cycle_name in completed_steps:
-                        completed_timestamp = previous_timestamp
+                if previous_timestamp is not None:
+                    item[cycle_name] = previous_timestamp
+                    if cycle_name == done_column:
+                        done_timestamp = previous_timestamp
+                    if cycle_name == committed_column:
+                        committed_timestamp = previous_timestamp
 
-            if accepted_timestamp is not None and completed_timestamp is not None:
-                item['cycle_time'] = completed_timestamp - accepted_timestamp
-                item['completed_timestamp'] = completed_timestamp
+            if committed_timestamp is not None and done_timestamp is not None:
+                item['cycle_time'] = done_timestamp - committed_timestamp
+                item['completed_timestamp'] = done_timestamp
+
 
             for k, v in item.items():
                 series[k]['data'].append(v)

--- a/jira_agile_metrics/calculators/cycletime_test.py
+++ b/jira_agile_metrics/calculators/cycletime_test.py
@@ -107,6 +107,22 @@ def jira_with_skipped_columns(custom_fields):
                 Change("2018-01-04 01:01:01", [("status", "Next", "Done",), ("resolution", None, "done")]), # skipping columns Build and Test
             ],
         ),
+        Issue("A-11",
+            summary="More Gaps",
+            issuetype=Value("Story", "story"),
+            status=Value("Done", "done"),
+            resolution=Value("Done", "Done"),
+            resolutiondate="2018-01-04 01:01:01",
+            created="2018-01-01 01:01:01",
+            customfield_001="Team 1",
+            customfield_002=Value(None, 10),
+            customfield_003=Value(None, []),
+            customfield_100=None,
+            changes=[
+                Change("2018-01-02 01:05:01", [("status", "Backlog", "Build",)]),
+                Change("2018-01-04 01:01:01", [("status", "Build", "Done",), ("resolution", None, "done")]), # skipping columns Build and Test
+            ],
+        ),
     ])
 
 @pytest.fixture
@@ -282,6 +298,28 @@ def test_movement_skipped_columns(jira_with_skipped_columns, settings):
         'Backlog': Timestamp('2018-01-01 00:00:00'),
         'Committed': Timestamp('2018-01-02 00:00:00'),
         'Build': Timestamp('2018-01-04 00:00:00'),
+        'Test': Timestamp('2018-01-04 00:00:00'),
+        'Done': Timestamp('2018-01-04 00:00:00'),
+    }, {
+        'key': 'A-11',
+        'url': 'https://example.org/browse/A-11',
+        'issue_type': 'Story',
+        'summary': 'More Gaps',
+        'status': 'Done',
+        'resolution': 'Done',
+
+        'Estimate': 10,
+        'Release': 'None',
+        'Team': 'Team 1',
+
+        'completed_timestamp': Timestamp('2018-01-04 00:00:00'),
+        'cycle_time': Timedelta('2 days 00:00:00'),
+        'blocked_days': 0,
+        'impediments': [],
+
+        'Backlog': Timestamp('2018-01-01 00:00:00'),
+        'Committed': Timestamp('2018-01-02 00:00:00'),
+        'Build': Timestamp('2018-01-02 00:00:00'),
         'Test': Timestamp('2018-01-04 00:00:00'),
         'Done': Timestamp('2018-01-04 00:00:00'),
     }]

--- a/jira_agile_metrics/calculators/forecast.py
+++ b/jira_agile_metrics/calculators/forecast.py
@@ -29,11 +29,11 @@ class BurnupForecastCalculator(Calculator):
             logger.debug("Not calculating burnup forecast chart data as no output file specified")
             return None
 
-        committed_column = self.settings['committed_column']
+        backlog_column = self.settings['backlog_column']
         done_column = self.settings['done_column']
 
-        if committed_column not in burnup_data.columns:
-            logger.error("Committed column %s does not exist", committed_column)
+        if backlog_column not in burnup_data.columns:
+            logger.error("Backlog column %s does not exist", backlog_column)
             return None
         if done_column not in burnup_data.columns:
             logger.error("Done column %s does not exist", done_column)
@@ -49,7 +49,7 @@ class BurnupForecastCalculator(Calculator):
         logger.info("Sampling throughput between %s and %s", throughput_window_start.isoformat(), throughput_window_end.isoformat())
 
         start_value = burnup_data[done_column].max()
-        target = self.settings['burnup_forecast_chart_target'] or burnup_data[committed_column].max()
+        target = self.settings['burnup_forecast_chart_target'] or burnup_data[backlog_column].max()
         logger.info("Running forecast to completion of %d items", target)
 
         trials = self.settings['burnup_forecast_chart_trials']
@@ -110,8 +110,8 @@ class BurnupForecastCalculator(Calculator):
         quantiles = self.settings['quantiles']
         logger.debug("Showing forecast at quantiles %s", ', '.join(['%.2f' % (q * 100.0) for q in quantiles]))
 
-        committed_column = self.settings['committed_column']
-        target = self.settings['burnup_forecast_chart_target'] or burnup_data[committed_column].max()
+        backlog_column = self.settings['backlog_column']
+        target = self.settings['burnup_forecast_chart_target'] or burnup_data[backlog_column].max()
 
         fig, ax = plt.subplots()
 

--- a/jira_agile_metrics/calculators/forecast.py
+++ b/jira_agile_metrics/calculators/forecast.py
@@ -29,14 +29,14 @@ class BurnupForecastCalculator(Calculator):
             logger.debug("Not calculating burnup forecast chart data as no output file specified")
             return None
 
-        backlog_column = self.settings['backlog_column']
+        committed_column = self.settings['committed_column']
         done_column = self.settings['done_column']
 
-        if backlog_column not in burnup_data.columns:
-            logger.error("Backlog column %s does not exist", backlog_column)
+        if committed_column not in burnup_data.columns:
+            logger.error("Committed column %s does not exist", committed_column)
             return None
         if done_column not in burnup_data.columns:
-            logger.error("Backlog column %s does not exist", done_column)
+            logger.error("Done column %s does not exist", done_column)
             return None
 
         if cycle_data[done_column].max() is pd.NaT:
@@ -49,7 +49,7 @@ class BurnupForecastCalculator(Calculator):
         logger.info("Sampling throughput between %s and %s", throughput_window_start.isoformat(), throughput_window_end.isoformat())
 
         start_value = burnup_data[done_column].max()
-        target = self.settings['burnup_forecast_chart_target'] or burnup_data[backlog_column].max()
+        target = self.settings['burnup_forecast_chart_target'] or burnup_data[committed_column].max()
         logger.info("Running forecast to completion of %d items", target)
 
         trials = self.settings['burnup_forecast_chart_trials']
@@ -64,7 +64,7 @@ class BurnupForecastCalculator(Calculator):
         if throughput_data['count'].sum() <= 0:
             logger.warning("No throughput samples available, aborting forecast simulations")
             return None
-        
+
         return burnup_monte_carlo(
             start_value=start_value,
             target_value=target,
@@ -110,8 +110,8 @@ class BurnupForecastCalculator(Calculator):
         quantiles = self.settings['quantiles']
         logger.debug("Showing forecast at quantiles %s", ', '.join(['%.2f' % (q * 100.0) for q in quantiles]))
 
-        backlog_column = self.settings['backlog_column']
-        target = self.settings['burnup_forecast_chart_target'] or burnup_data[backlog_column].max()
+        committed_column = self.settings['committed_column']
+        target = self.settings['burnup_forecast_chart_target'] or burnup_data[committed_column].max()
 
         fig, ax = plt.subplots()
 
@@ -255,7 +255,7 @@ def throughput_sampler(throughput_data, start_value, target):
 
         sample_buffer['idx'] += 1
         return sample_buffer['buffer'].iloc[sample_buffer['idx'] - 1]
-    
+
     return get_throughput_sample
 
 def burnup_monte_carlo(

--- a/jira_agile_metrics/calculators/forecast_test.py
+++ b/jira_agile_metrics/calculators/forecast_test.py
@@ -92,7 +92,7 @@ def test_calculate_forecast(query_manager, settings, results):
 def test_calculate_forecast_settings(query_manager, settings, results):
 
     settings.update({
-        'committed_column': 'Committed',
+        'backlog_column': 'Committed',
         'done_column': 'Test',
         'burnup_forecast_chart_throughput_window_end': datetime.date(2018, 1, 6),
         'burnup_forecast_chart_throughput_window': 4,

--- a/jira_agile_metrics/calculators/forecast_test.py
+++ b/jira_agile_metrics/calculators/forecast_test.py
@@ -72,7 +72,7 @@ def test_calculate_forecast(query_manager, settings, results):
     assert len(data.index) > 0
     assert list(data.index)[0] == Timestamp('2018-01-09 00:00:00', freq='D')
     assert list(data.index)[1] == Timestamp('2018-01-10 00:00:00', freq='D')
-    
+
     for i in range(10):
         trial_values = data['Trial %d' % i]
 
@@ -92,7 +92,7 @@ def test_calculate_forecast(query_manager, settings, results):
 def test_calculate_forecast_settings(query_manager, settings, results):
 
     settings.update({
-        'backlog_column': 'Committed',
+        'committed_column': 'Committed',
         'done_column': 'Test',
         'burnup_forecast_chart_throughput_window_end': datetime.date(2018, 1, 6),
         'burnup_forecast_chart_throughput_window': 4,
@@ -115,7 +115,7 @@ def test_calculate_forecast_settings(query_manager, settings, results):
     assert len(data.index) > 0
     assert list(data.index)[0] == Timestamp('2018-01-09 00:00:00', freq='D')
     assert list(data.index)[1] == Timestamp('2018-01-10 00:00:00', freq='D')
-    
+
     for i in range(10):
         trial_values = data['Trial %d' % i]
 

--- a/jira_agile_metrics/calculators/impediments.py
+++ b/jira_agile_metrics/calculators/impediments.py
@@ -32,21 +32,23 @@ class ImpedimentsCalculator(Calculator):
         ):
             logger.debug("Not calculating impediments data as no output files specified")
             return None
-        
-        backlog_column = self.settings['backlog_column']
-        done_column = self.settings['done_column']
 
         cycle_data = self.get_result(CycleTimeCalculator)
         cycle_data = cycle_data[cycle_data.blocked_days > 0][['key', 'impediments']]
-        
+
         data = []
+
+        cycle_names = [s['name'] for s in self.settings['cycle']]
+        committed_column = self.settings['committed_column']
+        done_column = self.settings['done_column']
+        active_columns = cycle_names[cycle_names.index(committed_column):cycle_names.index(done_column)]
 
         for row in cycle_data.itertuples():
             for idx, event in enumerate(row.impediments):
                 # Ignore things that were impeded whilst in the backlog and/or done column
                 # (these are mostly nonsensical, and don't really indicate blocked/wasted time)
 
-                if event['status'] in (backlog_column, done_column):
+                if event['status'] not in active_columns:
                     continue
                 data.append({
                     'key': row.key,
@@ -55,7 +57,7 @@ class ImpedimentsCalculator(Calculator):
                     'start': pd.Timestamp(event['start']),
                     'end': pd.Timestamp(event['end']) if event['end'] else pd.NaT,
                 })
-        
+
         return pd.DataFrame(data, columns=['key', 'status', 'flag', 'start', 'end'])
 
     def write(self):
@@ -68,16 +70,16 @@ class ImpedimentsCalculator(Calculator):
 
         if self.settings['impediments_chart']:
             self.write_impediments_chart(data, self.settings['impediments_chart'])
-        
+
         if self.settings['impediments_days_chart']:
             self.write_impediments_days_chart(data, self.settings['impediments_days_chart'])
-        
+
         if self.settings['impediments_status_chart']:
             self.write_impediments_status_chart(data, self.settings['impediments_status_chart'])
-        
+
         if self.settings['impediments_status_days_chart']:
             self.write_impediments_status_days_chart(data, self.settings['impediments_status_days_chart'])
-    
+
     def write_data(self, data, output_files):
         for output_file in output_files:
             output_extension = get_extension(output_file)
@@ -94,10 +96,10 @@ class ImpedimentsCalculator(Calculator):
         if len(chart_data.index) == 0:
             logger.warning("Cannot draw impediments chart with zero items")
             return
-        
+
         window = self.settings['impediments_window']
         breakdown = breakdown_by_month(chart_data, 'start', 'end', 'key', 'flag')
-        
+
         if window:
             breakdown = breakdown[-window:]
 
@@ -106,9 +108,9 @@ class ImpedimentsCalculator(Calculator):
             return
 
         fig, ax = plt.subplots()
-        
+
         breakdown.plot.bar(ax=ax, stacked=True)
-        
+
         if self.settings['impediments_chart_title']:
             ax.set_title(self.settings['impediments_chart_title'])
 
@@ -125,7 +127,7 @@ class ImpedimentsCalculator(Calculator):
         logger.info("Writing impediments chart to %s", output_file)
         fig.savefig(output_file, bbox_inches='tight', dpi=300)
         plt.close(fig)
-    
+
     def write_impediments_days_chart(self, chart_data, output_file):
         if len(chart_data.index) == 0:
             logger.warning("Cannot draw impediments days chart with zero items")
@@ -133,7 +135,7 @@ class ImpedimentsCalculator(Calculator):
 
         window = self.settings['impediments_window']
         breakdown = breakdown_by_month_sum_days(chart_data, 'start', 'end', 'flag')
-        
+
         if window:
             breakdown = breakdown[-window:]
 
@@ -142,9 +144,9 @@ class ImpedimentsCalculator(Calculator):
             return
 
         fig, ax = plt.subplots()
-        
+
         breakdown.plot.bar(ax=ax, stacked=True)
-        
+
         if self.settings['impediments_days_chart_title']:
             ax.set_title(self.settings['impediments_days_chart_title'])
 
@@ -161,17 +163,17 @@ class ImpedimentsCalculator(Calculator):
         logger.info("Writing impediments days chart to %s", output_file)
         fig.savefig(output_file, bbox_inches='tight', dpi=300)
         plt.close(fig)
-    
+
     def write_impediments_status_chart(self, chart_data, output_file):
         if len(chart_data.index) == 0:
             logger.warning("Cannot draw impediments status chart with zero items")
             return
-        
+
         window = self.settings['impediments_window']
         cycle_names = [s['name'] for s in self.settings['cycle']]
 
         breakdown = breakdown_by_month(chart_data, 'start', 'end', 'key', 'status', cycle_names)
-        
+
         if window:
             breakdown = breakdown[-window:]
 
@@ -180,9 +182,9 @@ class ImpedimentsCalculator(Calculator):
             return
 
         fig, ax = plt.subplots()
-        
+
         breakdown.plot.bar(ax=ax, stacked=True)
-        
+
         if self.settings['impediments_status_chart_title']:
             ax.set_title(self.settings['impediments_status_chart_title'])
 
@@ -199,7 +201,7 @@ class ImpedimentsCalculator(Calculator):
         logger.info("Writing impediments status chart to %s", output_file)
         fig.savefig(output_file, bbox_inches='tight', dpi=300)
         plt.close(fig)
-    
+
     def write_impediments_status_days_chart(self, chart_data, output_file):
         if len(chart_data.index) == 0:
             logger.warning("Cannot draw impediments status days chart with zero items")
@@ -209,7 +211,7 @@ class ImpedimentsCalculator(Calculator):
         cycle_names = [s['name'] for s in self.settings['cycle']]
 
         breakdown = breakdown_by_month_sum_days(chart_data, 'start', 'end', 'status', cycle_names)
-        
+
         if window:
             breakdown = breakdown[-window:]
 
@@ -218,9 +220,9 @@ class ImpedimentsCalculator(Calculator):
             return
 
         fig, ax = plt.subplots()
-        
+
         breakdown.plot.bar(ax=ax, stacked=True)
-        
+
         if self.settings['impediments_status_days_chart_title']:
             ax.set_title(self.settings['impediments_status_days_chart_title'])
 

--- a/jira_agile_metrics/calculators/impediments_test.py
+++ b/jira_agile_metrics/calculators/impediments_test.py
@@ -50,7 +50,7 @@ def cycle_time_results(minimal_cycle_time_columns):
             ]),
         ]), columns=minimal_cycle_time_columns)
     }
-    
+
 def test_only_runs_if_charts_set(query_manager, settings, cycle_time_results):
     test_settings = extend_dict(settings, {
         'impediments_data': None,
@@ -152,9 +152,9 @@ def test_calculate_impediments(query_manager, settings, cycle_time_results):
         {'key': 'A-4', 'status': 'Committed', 'flag': 'Awaiting input', 'start': _ts('2018-01-05'), 'end': NaT},
     ]
 
-def test_different_backlog_column(query_manager, settings, cycle_time_results):
+def test_different_committed_column(query_manager, settings, cycle_time_results):
     settings = extend_dict(settings, {
-        'backlog_column': 'Committed',
+        'committed_column': 'Backlog',
     })
     calculator = ImpedimentsCalculator(query_manager, settings, cycle_time_results)
 
@@ -162,7 +162,9 @@ def test_different_backlog_column(query_manager, settings, cycle_time_results):
 
     assert data.to_dict('records') == [
         {'key': 'A-2', 'status': 'Backlog', 'flag': 'Impediment', 'start': _ts('2018-01-05'), 'end': _ts('2018-01-07')},
-        {'key': 'A-3', 'status': 'Build',   'flag': 'Impediment', 'start': _ts('2018-01-04'), 'end': _ts('2018-01-05')},
+        {'key': 'A-2', 'status': 'Committed', 'flag': 'Impediment',     'start': _ts('2018-01-10'), 'end': _ts('2018-01-12')},
+        {'key': 'A-3', 'status': 'Build',     'flag': 'Impediment',     'start': _ts('2018-01-04'), 'end': _ts('2018-01-05')},
+        {'key': 'A-4', 'status': 'Committed', 'flag': 'Awaiting input', 'start': _ts('2018-01-05'), 'end': NaT},
     ]
 
 def test_different_done_column(query_manager, settings, cycle_time_results):
@@ -175,6 +177,5 @@ def test_different_done_column(query_manager, settings, cycle_time_results):
 
     assert data.to_dict('records') == [
         {'key': 'A-2', 'status': 'Committed', 'flag': 'Impediment',     'start': _ts('2018-01-10'), 'end': _ts('2018-01-12')},
-        {'key': 'A-3', 'status': 'Done',      'flag': 'Impediment',     'start': _ts('2018-01-07'), 'end': _ts('2018-01-10')},
         {'key': 'A-4', 'status': 'Committed', 'flag': 'Awaiting input', 'start': _ts('2018-01-05'), 'end': NaT},
     ]

--- a/jira_agile_metrics/calculators/progressreport_test.py
+++ b/jira_agile_metrics/calculators/progressreport_test.py
@@ -143,7 +143,7 @@ def query_manager(fields, settings):
                 customfield_202=None,
                 changes=[]
             ),
-            
+
             # Epics
             Issue("E-1",
                 summary="Epic 1",
@@ -219,7 +219,7 @@ def query_manager(fields, settings):
                 customfield_204=0,
                 changes=[]
             ),
-            
+
 
             # Stories for epic E-1
             Issue("A-1",
@@ -375,7 +375,7 @@ def test_throughput_range_sampler():
     sampler = throughput_range_sampler(5, 5)
     for i in range(10):
         assert sampler() == 5
-    
+
     sampler = throughput_range_sampler(5, 10)
     for i in range(10):
         assert 5 <= sampler() <= 10
@@ -393,7 +393,7 @@ def test_calculate_epic_target():
         deadline=None,
         stories_raised=None
     )) == 5
-    
+
     assert calculate_epic_target(Epic(
         key='E-1',
         summary='Epic 1',
@@ -406,7 +406,7 @@ def test_calculate_epic_target():
         deadline=None,
         stories_raised=None
     )) == 8
-    
+
     assert calculate_epic_target(Epic(
         key='E-1',
         summary='Epic 1',
@@ -421,7 +421,7 @@ def test_calculate_epic_target():
     )) <= 3
 
 def test_find_outcomes(query_manager):
-    
+
     outcomes = list(find_outcomes(
         query_manager=query_manager,
         query="issuetype=outcome",
@@ -430,7 +430,7 @@ def test_find_outcomes(query_manager):
     ))
 
     assert len(outcomes) == 2
-    
+
     assert outcomes[0].key == "O-1"
     assert outcomes[0].name == "Outcome ticket one"
     assert outcomes[0].deadline == datetime(2018, 5, 1, 0, 0, 0)
@@ -442,7 +442,7 @@ def test_find_outcomes(query_manager):
     assert outcomes[1].epic_query == 'issuetype=epic AND Outcome="O-2"'
 
 def test_find_outcomes_no_deadline_field(query_manager):
-    
+
     outcomes = list(find_outcomes(
         query_manager=query_manager,
         query="issuetype=outcome",
@@ -451,7 +451,7 @@ def test_find_outcomes_no_deadline_field(query_manager):
     ))
 
     assert len(outcomes) == 2
-    
+
     assert outcomes[0].key == "O-1"
     assert outcomes[0].name == "Outcome ticket one"
     assert outcomes[0].deadline is None
@@ -465,7 +465,7 @@ def test_find_outcomes_no_deadline_field(query_manager):
 def test_find_epics(query_manager):
 
     outcome = Outcome("Outcome one", "O1", None, 'issuetype=epic AND Outcome=O1')
-    
+
     epics = list(find_epics(
         query_manager=query_manager,
         epic_min_stories_field='customfield_203',
@@ -543,7 +543,7 @@ def test_find_epics_minimal_fields(query_manager):
 def test_find_epics_defaults_to_outcome_deadline(query_manager):
 
     outcome = Outcome("Outcome one", "O1", datetime(2019, 6, 1), 'issuetype=epic AND Outcome=O1')
-    
+
     epics = list(find_epics(
         query_manager=query_manager,
         epic_min_stories_field='customfield_203',
@@ -584,7 +584,7 @@ def test_find_epics_defaults_to_outcome_deadline(query_manager):
     assert epics[2].deadline == datetime(2019, 6, 1, 0, 0)
 
 def test_update_story_counts(query_manager, settings):
-    
+
     e1 = Epic(
         key="E-1",
         summary="Epic 1",
@@ -602,7 +602,7 @@ def test_update_story_counts(query_manager, settings):
         epic=e1,
         query_manager=query_manager,
         cycle=settings['cycle'],
-        backlog_column=settings['backlog_column'],
+        committed_column=settings['committed_column'],
         done_column=settings['done_column']
     )
 
@@ -633,7 +633,7 @@ def test_update_story_counts(query_manager, settings):
         epic=e2,
         query_manager=query_manager,
         cycle=settings['cycle'],
-        backlog_column=settings['backlog_column'],
+        committed_column=settings['committed_column'],
         done_column=settings['done_column']
     )
 
@@ -664,7 +664,7 @@ def test_update_story_counts(query_manager, settings):
         epic=e3,
         query_manager=query_manager,
         cycle=settings['cycle'],
-        backlog_column=settings['backlog_column'],
+        committed_column=settings['committed_column'],
         done_column=settings['done_column']
     )
 
@@ -693,7 +693,7 @@ def test_calculate_team_throughput(query_manager, settings):
         team=t,
         query_manager=query_manager,
         cycle=settings['cycle'],
-        backlog_column=settings['backlog_column'],
+        committed_column=settings['committed_column'],
         done_column=settings['done_column'],
         frequency='1D'
     )
@@ -723,7 +723,7 @@ def test_calculate_team_throughput(query_manager, settings):
         team=t,
         query_manager=query_manager,
         cycle=settings['cycle'],
-        backlog_column=settings['backlog_column'],
+        committed_column=settings['committed_column'],
         done_column=settings['done_column'],
         frequency='1D'
     )
@@ -751,7 +751,7 @@ def test_calculate_team_throughput(query_manager, settings):
         team=t,
         query_manager=query_manager,
         cycle=settings['cycle'],
-        backlog_column=settings['backlog_column'],
+        committed_column=settings['committed_column'],
         done_column=settings['done_column'],
         frequency='1D'
     )
@@ -773,7 +773,7 @@ def test_calculate_team_throughput(query_manager, settings):
     assert isinstance(t.throughput_samples_cycle_times, pd.DataFrame)
 
 def test_update_team_sampler(query_manager, settings):
-    
+
     # min/max only
 
     t = Team(
@@ -789,7 +789,7 @@ def test_update_team_sampler(query_manager, settings):
         team=t,
         query_manager=query_manager,
         cycle=settings['cycle'],
-        backlog_column=settings['backlog_column'],
+        committed_column=settings['committed_column'],
         done_column=settings['done_column'],
         frequency='1D'
     )
@@ -812,7 +812,7 @@ def test_update_team_sampler(query_manager, settings):
         team=t,
         query_manager=query_manager,
         cycle=settings['cycle'],
-        backlog_column=settings['backlog_column'],
+        committed_column=settings['committed_column'],
         done_column=settings['done_column'],
         frequency='1D'
     )
@@ -835,7 +835,7 @@ def test_update_team_sampler(query_manager, settings):
         team=t,
         query_manager=query_manager,
         cycle=settings['cycle'],
-        backlog_column=settings['backlog_column'],
+        committed_column=settings['committed_column'],
         done_column=settings['done_column'],
         frequency='1D'
     )
@@ -858,7 +858,7 @@ def test_update_team_sampler(query_manager, settings):
         team=t,
         query_manager=query_manager,
         cycle=settings['cycle'],
-        backlog_column=settings['backlog_column'],
+        committed_column=settings['committed_column'],
         done_column=settings['done_column'],
         frequency='1D'
     )
@@ -881,7 +881,7 @@ def test_update_team_sampler(query_manager, settings):
         team=t,
         query_manager=query_manager,
         cycle=settings['cycle'],
-        backlog_column=settings['backlog_column'],
+        committed_column=settings['committed_column'],
         done_column=settings['done_column'],
         frequency='1D'
     )
@@ -890,7 +890,7 @@ def test_update_team_sampler(query_manager, settings):
     assert isinstance(t.throughput_samples_cycle_times, pd.DataFrame)
 
 def test_forecast_to_complete_wip_1():
-    
+
     team = Team(
         name='Team 1',
         wip=1,
@@ -1052,7 +1052,7 @@ def test_forecast_to_complete_no_epics():
     assert len(epics) == 0
 
 def test_forecast_to_complete_with_randomness():
-    
+
     team = Team(
         name='Team 1',
         wip=2,
@@ -1126,7 +1126,7 @@ def test_forecast_to_complete_with_randomness():
     assert epics[2].forecast.deadline_quantile == 1  # deadline is after worst case scenario
 
 def test_calculator(query_manager, settings, results):
-    
+
     calculator = ProgressReportCalculator(query_manager, settings, results)
 
     data = calculator.run(trials=10, now=datetime(2018, 1, 10))
@@ -1161,7 +1161,7 @@ def test_calculator(query_manager, settings, results):
 
     # confirm teams
     assert len(data['teams']) == 2
-    
+
     assert data['teams'][0].name == 'Team 1'
     assert data['teams'][0].min_throughput == 5
     assert data['teams'][0].max_throughput == 10
@@ -1182,7 +1182,7 @@ def test_calculator_no_outcomes(query_manager, settings, results):
         'progress_report_epic_query_template': 'issuetype=epic AND Outcome="O1',
         'progress_report_outcomes': [],
     })
-    
+
     calculator = ProgressReportCalculator(query_manager, settings, results)
 
     data = calculator.run(trials=10, now=datetime(2018, 1, 10))
@@ -1213,7 +1213,7 @@ def test_calculator_no_outcomes(query_manager, settings, results):
 
     # confirm teams
     assert len(data['teams']) == 2
-    
+
     assert data['teams'][0].name == 'Team 1'
     assert data['teams'][0].min_throughput == 5
     assert data['teams'][0].max_throughput == 10
@@ -1281,7 +1281,7 @@ def test_calculator_no_fields(query_manager, settings, results):
 
     # confirm teams
     assert len(data['teams']) == 1
-    
+
     assert data['teams'][0].name == 'Team 1'
     assert data['teams'][0].min_throughput == 5
     assert data['teams'][0].max_throughput == 10
@@ -1308,7 +1308,7 @@ def test_with_large_dataset(fields, settings, results):
     def simple_ql(i, jql):
         clauses = [c.strip() for c in jql.split(' AND ') if "=" in c]
         return all([compare_value(i, c) for c in clauses])
-    
+
     settings = extend_dict(settings, {
         'quantiles': [0.75, 0.85, 0.95],
         'progress_report': 'progress-large.html',
@@ -1352,7 +1352,7 @@ def test_with_large_dataset(fields, settings, results):
 
     teams = [t['name'] for t in settings['progress_report_teams']]
     outcomes = [o['key'] for o in settings['progress_report_outcomes']]
-      
+
     epics = [Issue("E-%d" % i,
         summary="%s %s" % (random.choice(verbs).capitalize(), random.choice(nouns)),
         issuetype=Value('Epic', 'epic'),
@@ -1378,7 +1378,7 @@ def test_with_large_dataset(fields, settings, results):
             'from': None,
             'to': statuses[0]
         }]
-        
+
         for s in statuses[1:]:
             changes.append({
                 'date': random_date_future(changes[-1]['date'], 15),
@@ -1442,7 +1442,7 @@ def test_with_large_dataset_and_outcome_as_tickets(fields, settings, results):
     def simple_ql(i, jql):
         clauses = [c.strip() for c in jql.split(' AND ') if "=" in c]
         return all([compare_value(i, c) for c in clauses])
-    
+
     settings = extend_dict(settings, {
         'quantiles': [0.75, 0.85, 0.95],
         'progress_report': 'progress-outcome-tickets.html',
@@ -1470,7 +1470,7 @@ def test_with_large_dataset_and_outcome_as_tickets(fields, settings, results):
     })
 
     teams = [t['name'] for t in settings['progress_report_teams']]
-    
+
     outcomes = [Issue("O-%d" % i,
         summary="%s %s" % (random.choice(verbs).capitalize(), random.choice(nouns)),
         issuetype=Value('Outcome', 'outcome'),
@@ -1481,7 +1481,7 @@ def test_with_large_dataset_and_outcome_as_tickets(fields, settings, results):
         customfield_202="%s 00:00:00" % random_date_future(today + timedelta(days=55), 65).isoformat() if random.choice((True, True, False,)) else None,
         changes=[]
     ) for i in range(random.randint(2, 4))]
-        
+
     epics = [Issue("E-%d" % i,
         summary="%s %s" % (random.choice(verbs).capitalize(), random.choice(nouns)),
         issuetype=Value('Epic', 'epic'),
@@ -1507,7 +1507,7 @@ def test_with_large_dataset_and_outcome_as_tickets(fields, settings, results):
             'from': None,
             'to': statuses[0]
         }]
-        
+
         for s in statuses[1:]:
             changes.append({
                 'date': random_date_future(changes[-1]['date'], 15),
@@ -1570,7 +1570,7 @@ def test_with_large_dataset_and_outcome_as_tickets_no_forecast(fields, settings,
     def simple_ql(i, jql):
         clauses = [c.strip() for c in jql.split(' AND ') if "=" in c]
         return all([compare_value(i, c) for c in clauses])
-    
+
     settings = extend_dict(settings, {
         'quantiles': [0.75, 0.85, 0.95],
         'progress_report': 'progress-no-forecast.html',
@@ -1598,7 +1598,7 @@ def test_with_large_dataset_and_outcome_as_tickets_no_forecast(fields, settings,
     })
 
     teams = [t['name'] for t in settings['progress_report_teams']]
-    
+
     outcomes = [Issue("O-%d" % i,
         summary="%s %s" % (random.choice(verbs).capitalize(), random.choice(nouns)),
         issuetype=Value('Outcome', 'outcome'),
@@ -1609,7 +1609,7 @@ def test_with_large_dataset_and_outcome_as_tickets_no_forecast(fields, settings,
         customfield_202="%s 00:00:00" % random_date_future(today + timedelta(days=55), 65).isoformat() if random.choice((True, True, False,)) else None,
         changes=[]
     ) for i in range(random.randint(2, 4))]
-        
+
     epics = [Issue("E-%d" % i,
         summary="%s %s" % (random.choice(verbs).capitalize(), random.choice(nouns)),
         issuetype=Value('Epic', 'epic'),
@@ -1635,7 +1635,7 @@ def test_with_large_dataset_and_outcome_as_tickets_no_forecast(fields, settings,
             'from': None,
             'to': statuses[0]
         }]
-        
+
         for s in statuses[1:]:
             changes.append({
                 'date': random_date_future(changes[-1]['date'], 15),
@@ -1698,7 +1698,7 @@ def test_with_large_dataset_and_outcome_as_tickets_mixed_forecast(fields, settin
     def simple_ql(i, jql):
         clauses = [c.strip() for c in jql.split(' AND ') if "=" in c]
         return all([compare_value(i, c) for c in clauses])
-    
+
     settings = extend_dict(settings, {
         'quantiles': [0.75, 0.85, 0.95],
         'progress_report': 'progress-mixed-forecasts.html',
@@ -1726,7 +1726,7 @@ def test_with_large_dataset_and_outcome_as_tickets_mixed_forecast(fields, settin
     })
 
     teams = [t['name'] for t in settings['progress_report_teams']]
-    
+
     outcomes = [Issue("O-%d" % i,
         summary="%s %s" % (random.choice(verbs).capitalize(), random.choice(nouns)),
         issuetype=Value('Outcome', 'outcome'),
@@ -1737,7 +1737,7 @@ def test_with_large_dataset_and_outcome_as_tickets_mixed_forecast(fields, settin
         customfield_202="%s 00:00:00" % random_date_future(today + timedelta(days=55), 65).isoformat() if random.choice((True, True, False,)) else None,
         changes=[]
     ) for i in range(random.randint(2, 4))]
-        
+
     epics = [Issue("E-%d" % i,
         summary="%s %s" % (random.choice(verbs).capitalize(), random.choice(nouns)),
         issuetype=Value('Epic', 'epic'),
@@ -1763,7 +1763,7 @@ def test_with_large_dataset_and_outcome_as_tickets_mixed_forecast(fields, settin
             'from': None,
             'to': statuses[0]
         }]
-        
+
         for s in statuses[1:]:
             changes.append({
                 'date': random_date_future(changes[-1]['date'], 15),
@@ -1826,7 +1826,7 @@ def test_with_large_dataset_minimal(fields, settings, results):
     def simple_ql(i, jql):
         clauses = [c.strip() for c in jql.split(' AND ') if "=" in c]
         return all([compare_value(i, c) for c in clauses])
-    
+
     settings = extend_dict(settings, {
         'quantiles': [0.75, 0.85, 0.95],
         'progress_report_title': 'Acme Corp Websites',
@@ -1872,7 +1872,7 @@ def test_with_large_dataset_minimal(fields, settings, results):
             'from': None,
             'to': statuses[0]
         }]
-        
+
         for s in statuses[1:]:
             changes.append({
                 'date': random_date_future(changes[-1]['date'], 15),
@@ -1932,7 +1932,7 @@ def test_with_large_dataset_minimal_no_forecast(fields, settings, results):
     def simple_ql(i, jql):
         clauses = [c.strip() for c in jql.split(' AND ') if "=" in c]
         return all([compare_value(i, c) for c in clauses])
-    
+
     settings = extend_dict(settings, {
         'quantiles': [0.75, 0.85, 0.95],
         'progress_report': 'progress-minimal-no-forecast.html',
@@ -1957,7 +1957,7 @@ def test_with_large_dataset_minimal_no_forecast(fields, settings, results):
             },
         ],
     })
-        
+
     epics = [Issue("E-%d" % i,
         summary="%s %s" % (random.choice(verbs).capitalize(), random.choice(nouns)),
         issuetype=Value('Epic', 'epic'),
@@ -1978,7 +1978,7 @@ def test_with_large_dataset_minimal_no_forecast(fields, settings, results):
             'from': None,
             'to': statuses[0]
         }]
-        
+
         for s in statuses[1:]:
             changes.append({
                 'date': random_date_future(changes[-1]['date'], 15),
@@ -2038,7 +2038,7 @@ def test_with_large_dataset_teams_no_outcomes(fields, settings, results):
     def simple_ql(i, jql):
         clauses = [c.strip() for c in jql.split(' AND ') if "=" in c]
         return all([compare_value(i, c) for c in clauses])
-    
+
     settings = extend_dict(settings, {
         'quantiles': [0.75, 0.85, 0.95],
         'progress_report': 'progress-teams-no-outcomes.html',
@@ -2067,7 +2067,7 @@ def test_with_large_dataset_teams_no_outcomes(fields, settings, results):
     })
 
     teams = [t['name'] for t in settings['progress_report_teams']]
-    
+
     epics = [Issue("E-%d" % i,
         summary="%s %s" % (random.choice(verbs).capitalize(), random.choice(nouns)),
         issuetype=Value('Epic', 'epic'),
@@ -2093,7 +2093,7 @@ def test_with_large_dataset_teams_no_outcomes(fields, settings, results):
             'from': None,
             'to': statuses[0]
         }]
-        
+
         for s in statuses[1:]:
             changes.append({
                 'date': random_date_future(changes[-1]['date'], 15),
@@ -2156,7 +2156,7 @@ def test_with_large_dataset_no_teams(fields, settings, results):
     def simple_ql(i, jql):
         clauses = [c.strip() for c in jql.split(' AND ') if "=" in c]
         return all([compare_value(i, c) for c in clauses])
-    
+
     settings = extend_dict(settings, {
         'quantiles': [0.75, 0.85, 0.95],
         'progress_report': 'progress-no-teams.html',
@@ -2178,7 +2178,7 @@ def test_with_large_dataset_no_teams(fields, settings, results):
         customfield_202="%s 00:00:00" % random_date_future(today + timedelta(days=55), 65).isoformat() if random.choice((True, True, False,)) else None,
         changes=[]
     ) for i in range(random.randint(2, 4))]
-        
+
     epics = [Issue("E-%d" % i,
         summary="%s %s" % (random.choice(verbs).capitalize(), random.choice(nouns)),
         issuetype=Value('Epic', 'epic'),
@@ -2203,7 +2203,7 @@ def test_with_large_dataset_no_teams(fields, settings, results):
             'from': None,
             'to': statuses[0]
         }]
-        
+
         for s in statuses[1:]:
             changes.append({
                 'date': random_date_future(changes[-1]['date'], 15),
@@ -2265,7 +2265,7 @@ def test_with_large_dataset_dynamic_teams(fields, settings, results):
     def simple_ql(i, jql):
         clauses = [c.strip() for c in jql.split(' AND ') if "=" in c]
         return all([compare_value(i, c) for c in clauses])
-    
+
     settings = extend_dict(settings, {
         'quantiles': [0.75, 0.85, 0.95],
         'progress_report': 'progress-dynamic-teams.html',
@@ -2277,7 +2277,7 @@ def test_with_large_dataset_dynamic_teams(fields, settings, results):
     })
 
     teams = ["Alpha", "Beta", "Delta"]
-    
+
     outcomes = [Issue("O-%d" % i,
         summary="%s %s" % (random.choice(verbs).capitalize(), random.choice(nouns)),
         issuetype=Value('Outcome', 'outcome'),
@@ -2288,7 +2288,7 @@ def test_with_large_dataset_dynamic_teams(fields, settings, results):
         customfield_202="%s 00:00:00" % random_date_future(today + timedelta(days=55), 65).isoformat() if random.choice((True, True, False,)) else None,
         changes=[]
     ) for i in range(random.randint(2, 4))]
-        
+
     epics = [Issue("E-%d" % i,
         summary="%s %s" % (random.choice(verbs).capitalize(), random.choice(nouns)),
         issuetype=Value('Epic', 'epic'),
@@ -2314,7 +2314,7 @@ def test_with_large_dataset_dynamic_teams(fields, settings, results):
             'from': None,
             'to': statuses[0]
         }]
-        
+
         for s in statuses[1:]:
             changes.append({
                 'date': random_date_future(changes[-1]['date'], 15),
@@ -2375,7 +2375,7 @@ def test_with_large_dataset_static_and_dynamic_teams(fields, settings, results):
     def simple_ql(i, jql):
         clauses = [c.strip() for c in jql.split(' AND ') if "=" in c]
         return all([compare_value(i, c) for c in clauses])
-    
+
     settings = extend_dict(settings, {
         'quantiles': [0.75, 0.85, 0.95],
         'progress_report': 'progress-mixed-teams.html',
@@ -2396,7 +2396,7 @@ def test_with_large_dataset_static_and_dynamic_teams(fields, settings, results):
     })
 
     teams = [t['name'] for t in settings['progress_report_teams']] + ["Green", "Purple"]
-    
+
     outcomes = [Issue("O-%d" % i,
         summary="%s %s" % (random.choice(verbs).capitalize(), random.choice(nouns)),
         issuetype=Value('Outcome', 'outcome'),
@@ -2407,7 +2407,7 @@ def test_with_large_dataset_static_and_dynamic_teams(fields, settings, results):
         customfield_202="%s 00:00:00" % random_date_future(today + timedelta(days=55), 65).isoformat() if random.choice((True, True, False,)) else None,
         changes=[]
     ) for i in range(random.randint(2, 4))]
-        
+
     epics = [Issue("E-%d" % i,
         summary="%s %s" % (random.choice(verbs).capitalize(), random.choice(nouns)),
         issuetype=Value('Epic', 'epic'),
@@ -2433,7 +2433,7 @@ def test_with_large_dataset_static_and_dynamic_teams(fields, settings, results):
             'from': None,
             'to': statuses[0]
         }]
-        
+
         for s in statuses[1:]:
             changes.append({
                 'date': random_date_future(changes[-1]['date'], 15),

--- a/jira_agile_metrics/calculators/waste.py
+++ b/jira_agile_metrics/calculators/waste.py
@@ -24,8 +24,12 @@ class WasteCalculator(Calculator):
             logger.debug("Not calculating waste chart data as no query specified")
             return None
 
-        backlog_column = self.settings['backlog_column']
+        cycle_names = [s['name'] for s in self.settings['cycle']]
+        committed_column = self.settings['committed_column']
         done_column = self.settings['done_column']
+        active_columns = cycle_names[cycle_names.index(committed_column):cycle_names.index(done_column)]
+        inactive_columns = cycle_names.copy()
+        inactive_columns[cycle_names.index(committed_column):cycle_names.index(done_column)] = []
 
         cycle_lookup = {}
         for idx, cycle_step in enumerate(self.settings['cycle']):
@@ -33,7 +37,6 @@ class WasteCalculator(Calculator):
                 cycle_lookup[status.lower()] = dict(
                     index=idx,
                     name=cycle_step['name'],
-                    type=cycle_step['type'],
                 )
 
         columns = ['key', 'last_status', 'resolution', 'withdrawn_date']
@@ -61,7 +64,7 @@ class WasteCalculator(Calculator):
                 logger.warning("Issue %s transitioned from unknown JIRA status %s", issue.key, last_status)
 
             # Skip if last_status was the backlog or done column (not really withdrawn)
-            if last_status in (backlog_column, done_column):
+            if last_status in inactive_columns:
                 continue
 
             series['key']['data'].append(issue.key)
@@ -93,17 +96,15 @@ class WasteCalculator(Calculator):
         window = self.settings['waste_window']
 
         cycle_names = [s['name'] for s in self.settings['cycle']]
-        backlog_column = self.settings['backlog_column']
+        committed_column = self.settings['committed_column']
         done_column = self.settings['done_column']
-
-        cycle_names.remove(backlog_column)
-        cycle_names.remove(done_column)
+        active_columns = cycle_names[cycle_names.index(committed_column):cycle_names.index(done_column)]
 
         breakdown = chart_data \
                     .pivot_table(index='withdrawn_date', columns='last_status', values='key', aggfunc='count') \
                     .groupby(pd.Grouper(freq=frequency, closed='left', label='left')) \
                     .sum() \
-                    .reindex(cycle_names, axis=1)
+                    .reindex(active_columns, axis=1)
 
         if window:
             breakdown = breakdown[-window:]

--- a/jira_agile_metrics/calculators/waste_test.py
+++ b/jira_agile_metrics/calculators/waste_test.py
@@ -165,9 +165,9 @@ def test_query(jira, settings):
         {'key': 'A-7', 'last_status': None,        'resolution': 'Withdrawn', 'withdrawn_date': Timestamp('2018-01-06 02:02:02')},
     ]
 
-def test_different_backlog_column(jira, settings):
+def test_different_committed_column(jira, settings):
     settings = extend_dict(settings, {
-        'backlog_column': 'Committed'
+        'committed_column': 'Backlog'
     })
 
     query_manager = QueryManager(jira, settings)
@@ -178,6 +178,7 @@ def test_different_backlog_column(jira, settings):
 
     assert data.to_dict('records') == [
         {'key': 'A-1', 'last_status': 'Test',      'resolution': 'Withdrawn', 'withdrawn_date': Timestamp('2018-01-06 02:02:02')},
+        {'key': 'A-2', 'last_status': 'Committed', 'resolution': 'Withdrawn', 'withdrawn_date': Timestamp('2018-01-07 02:02:02')},
         {'key': 'A-4', 'last_status': 'Backlog',   'resolution': 'Withdrawn', 'withdrawn_date': Timestamp('2018-01-09 02:02:02')},
         {'key': 'A-6', 'last_status': 'foobar',    'resolution': 'Withdrawn', 'withdrawn_date': Timestamp('2018-01-06 02:02:02')},
         {'key': 'A-7', 'last_status': None,        'resolution': 'Withdrawn', 'withdrawn_date': Timestamp('2018-01-06 02:02:02')},
@@ -196,7 +197,6 @@ def test_different_done_column(jira, settings):
 
     assert data.to_dict('records') == [
         {'key': 'A-2', 'last_status': 'Committed', 'resolution': 'Withdrawn', 'withdrawn_date': Timestamp('2018-01-07 02:02:02')},
-        {'key': 'A-3', 'last_status': 'Done',      'resolution': 'Withdrawn', 'withdrawn_date': Timestamp('2018-01-08 02:02:02')},
         {'key': 'A-6', 'last_status': 'foobar',    'resolution': 'Withdrawn', 'withdrawn_date': Timestamp('2018-01-06 02:02:02')},
         {'key': 'A-7', 'last_status': None,        'resolution': 'Withdrawn', 'withdrawn_date': Timestamp('2018-01-06 02:02:02')},
     ]

--- a/jira_agile_metrics/calculators/wip.py
+++ b/jira_agile_metrics/calculators/wip.py
@@ -17,18 +17,11 @@ class WIPChartCalculator(Calculator):
         cfd_data = self.get_result(CFDCalculator)
         cycle_names = [s['name'] for s in self.settings['cycle']]
 
-        start_column = self.settings['committed_column']
+        committed_column = self.settings['committed_column']
         done_column = self.settings['done_column']
 
-        if start_column not in cycle_names:
-            logger.error("Committed column %s does not exist", start_column)
-            return None
-        if done_column not in cycle_names:
-            logger.error("Done column %s does not exist", done_column)
-            return None
-        
-        return pd.DataFrame({'wip': cfd_data[start_column] - cfd_data[done_column]}, index=cfd_data.index)
-    
+        return pd.DataFrame({'wip': cfd_data[committed_column] - cfd_data[done_column]}, index=cfd_data.index)
+
     def write(self):
         output_file = self.settings['wip_chart']
         if not output_file:
@@ -42,7 +35,7 @@ class WIPChartCalculator(Calculator):
             return
 
         fig, ax = plt.subplots()
-        
+
         if self.settings['wip_chart_title']:
             ax.set_title(self.settings['wip_chart_title'])
 

--- a/jira_agile_metrics/config.py
+++ b/jira_agile_metrics/config.py
@@ -111,7 +111,7 @@ def config_to_options(data, cwd=None, extended=False):
         config = ordered_load(data, yaml.SafeLoader)
     except Exception:
         raise ConfigError("Unable to parse YAML configuration file.") from None
-    
+
     if config is None:
         raise ConfigError("Configuration file is empty") from None
 
@@ -133,12 +133,11 @@ def config_to_options(data, cwd=None, extended=False):
             'cycle': [],
             'max_results': None,
             'verbose': False,
-        
+
             'quantiles': [0.5, 0.85, 0.95],
 
             'backlog_column': None,
             'committed_column': None,
-            'final_column': None,
             'done_column': None,
 
             'cycle_time_data': None,
@@ -148,7 +147,7 @@ def config_to_options(data, cwd=None, extended=False):
             'scatterplot_data': None,
             'scatterplot_chart': None,
             'scatterplot_chart_title': None,
-            
+
             'histogram_window': None,
             'histogram_data': None,
             'histogram_chart': None,
@@ -158,13 +157,13 @@ def config_to_options(data, cwd=None, extended=False):
             'cfd_data': None,
             'cfd_chart': None,
             'cfd_chart_title': None,
-            
+
             'throughput_frequency': '1W-MON',
             'throughput_window': None,
             'throughput_data': None,
             'throughput_chart': None,
             'throughput_chart_title': None,
-            
+
             'burnup_window': None,
             'burnup_chart': None,
             'burnup_chart_title': None,
@@ -202,7 +201,7 @@ def config_to_options(data, cwd=None, extended=False):
             'impediments_status_chart_title': None,
             'impediments_status_days_chart': None,
             'impediments_status_days_chart_title': None,
-            
+
             'defects_query': None,
             'defects_window': None,
             'defects_priority_field': None,
@@ -218,7 +217,7 @@ def config_to_options(data, cwd=None, extended=False):
             'defects_by_type_chart_title': None,
             'defects_by_environment_chart': None,
             'defects_by_environment_chart_title': None,
-        
+
             'debt_query': None,
             'debt_window': None,
             'debt_priority_field': None,
@@ -260,7 +259,7 @@ def config_to_options(data, cwd=None, extended=False):
 
         if not os.path.exists(extends_filename):
             raise ConfigError("File `%s` referenced in `extends` not found." % extends_filename) from None
-        
+
         logger.debug("Extending file %s" % extends_filename)
         with open(extends_filename) as extends_file:
             options = config_to_options(extends_file.read(), cwd=os.path.dirname(extends_filename), extended=True)
@@ -277,10 +276,10 @@ def config_to_options(data, cwd=None, extended=False):
 
         if 'password' in config['connection']:
             options['connection']['password'] = config['connection']['password']
-        
+
         if 'http proxy' in config['connection']:
             options['connection']['http_proxy'] = config['connection']['http proxy']
-        
+
         if 'https proxy' in config['connection']:
             options['connection']['https_proxy'] = config['connection']['https proxy']
 
@@ -319,7 +318,7 @@ def config_to_options(data, cwd=None, extended=False):
         ]:
             if expand_key(key) in config['output']:
                 options['settings'][key] = force_int(key, config['output'][expand_key(key)])
-        
+
         # float values
         for key in [
             'burnup_forecast_chart_deadline_confidence',
@@ -334,7 +333,7 @@ def config_to_options(data, cwd=None, extended=False):
         ]:
             if expand_key(key) in config['output']:
                 options['settings'][key] = force_date(key, config['output'][expand_key(key)])
-        
+
         # file name values
         for key in [
             'scatterplot_chart',
@@ -360,7 +359,7 @@ def config_to_options(data, cwd=None, extended=False):
         ]:
             if expand_key(key) in config['output']:
                 options['settings'][key] = os.path.basename(config['output'][expand_key(key)])
-        
+
         # file name list values
         for key in [
             'cycle_time_data',
@@ -369,7 +368,7 @@ def config_to_options(data, cwd=None, extended=False):
             'histogram_data',
             'throughput_data',
             'percentiles_data',
-            
+
             'impediments_data',
         ]:
             if expand_key(key) in config['output']:
@@ -390,7 +389,6 @@ def config_to_options(data, cwd=None, extended=False):
         for key in [
             'backlog_column',
             'committed_column',
-            'final_column',
             'done_column',
             'throughput_frequency',
             'scatterplot_chart_title',
@@ -464,24 +462,37 @@ def config_to_options(data, cwd=None, extended=False):
     if 'workflow' in config:
         if len(config['workflow'].keys()) < 3:
             raise ConfigError("`Workflow` section must contain at least three statuses")
-        
-        options['settings']['cycle'] = [{
-            "name": name,
-            "type": StatusTypes.accepted,
-            "statuses": force_list(statuses)
-        } for name, statuses in config['workflow'].items()]
 
-        options['settings']['cycle'][0]['type'] = StatusTypes.backlog
-        options['settings']['cycle'][-1]['type'] = StatusTypes.complete
+        column_names = []
+        for name, statuses in config['workflow'].items():
+            statuses = force_list(statuses)
+            options['settings']['cycle'].append({
+                "name": name,
+                "statuses": statuses
+            })
+            column_names.append(name)
+
+        if options['settings']['done_column'] is None:
+            options['settings']['done_column'] = options['settings']['cycle'][-1]['name']
+        elif options['settings']['done_column'] not in column_names:
+            raise ConfigError("`Done column` (%s) must exist in `Workflow`: %s", options['settings']['done_column'], options['settings']['workflow'])
+
+        if options['settings']['committed_column'] is None:
+            options['settings']['committed_column'] = options['settings']['cycle'][1]['name']
+        elif options['settings']['committed_column'] not in column_names:
+            raise ConfigError("`Committed column` (%s) must exist in `Workflow`: %s", options['settings']['committed_column'], options['settings']['workflow'])
 
         if options['settings']['backlog_column'] is None:
             options['settings']['backlog_column'] = options['settings']['cycle'][0]['name']
-        if options['settings']['committed_column'] is None:
-            options['settings']['committed_column'] = options['settings']['cycle'][1]['name']
-        if options['settings']['final_column'] is None:
-            options['settings']['final_column'] = options['settings']['cycle'][-2]['name']
-        if options['settings']['done_column'] is None:
-            options['settings']['done_column'] = options['settings']['cycle'][-1]['name']
+        elif options['settings']['backlog_column'] not in column_names:
+            raise ConfigError("`Backlog column` (%s) must exist in `Workflow`: %s", options['settings']['backlog_column'], options['settings']['workflow'])
+
+
+        if not column_names.index(options['settings']['committed_column']) < column_names.index(options['settings']['done_column']):
+            raise ConfigError("`Committed column` (%s) must come before `Done column` (%s) in `Workflow`", options['settings']['committed_column'], options['settings']['done_column'])
+
+        if not column_names.index(options['settings']['committed_column']) < column_names.index(options['settings']['done_column']):
+            raise ConfigError("`Backlog column` (%s) must come before `Committed column` (%s) in `Workflow`", options['settings']['backlog_column'], options['settings']['committed_column'])
 
     # Make sure we have workflow (but only if this file is not being extended by another)
     if not extended and len(options['settings']['cycle']) == 0:

--- a/jira_agile_metrics/config_test.py
+++ b/jira_agile_metrics/config_test.py
@@ -40,9 +40,8 @@ Workflow:
 
     assert options['settings']['backlog_column'] == 'Backlog'
     assert options['settings']['committed_column'] == 'In progress'
-    assert options['settings']['final_column'] == 'In progress'
     assert options['settings']['done_column'] == 'Done'
-    
+
 
 def test_config_to_options_maximal():
 
@@ -89,17 +88,16 @@ Output:
 
     Backlog column: Backlog
     Committed column: Committed
-    Final column: Test
     Done column: Done
 
     Cycle time data: cycletime.csv
     Percentiles data: percentiles.csv
-    
+
     Scatterplot window: 30
     Scatterplot data: scatterplot.csv
     Scatterplot chart: scatterplot.png
     Scatterplot chart title: Cycle time scatter plot
-    
+
     Histogram window: 30
     Histogram chart: histogram.png
     Histogram chart title: Cycle time histogram
@@ -110,7 +108,7 @@ Output:
     CFD chart title: Cumulative Flow Diagram
 
     Histogram data: histogram.csv
-    
+
     Throughput frequency: 1D
     Throughput window: 3
     Throughput data: throughput.csv
@@ -178,7 +176,7 @@ Output:
     Defects by type chart title: Defects by type
     Defects by environment chart: defects-by-environment.png
     Defects by environment chart title: Defects by environment
-    
+
     Debt query: issueType = "Tech debt"
     Debt window: 3
     Debt priority field: Priority
@@ -236,16 +234,14 @@ Output:
         'https_proxy': 'https://proxy2.local',
         'jira_server_version_check': True
     }
-   
+
     assert options['settings'] == {
         'cycle': [
-            {'name': 'Backlog', 'statuses': ['Backlog'], 'type': 'backlog'},
-            {'name': 'Committed', 'statuses': ['Next'], 'type': 'accepted'},
-            {'name': 'Build', 'statuses': ['Build'], 'type': 'accepted'},
-            {'name': 'Test',
-                'statuses': ['Code review', 'QA'],
-                'type': 'accepted'},
-            {'name': 'Done', 'statuses': ['Done'], 'type': 'complete'}
+            {'name': 'Backlog', 'statuses': ['Backlog']},
+            {'name': 'Committed', 'statuses': ['Next']},
+            {'name': 'Build', 'statuses': ['Build']},
+            {'name': 'Test', 'statuses': ['Code review', 'QA']},
+            {'name': 'Done', 'statuses': ['Done']}
         ],
 
         'attributes': {'Release': 'Fix version/s', 'Team': 'Team'},
@@ -256,23 +252,22 @@ Output:
         'queries': [{'jql': '(filter=123)', 'value': 'Team 1'},
                     {'jql': '(filter=124)', 'value': 'Team 2'}],
         'query_attribute': 'Team',
-                
+
         'backlog_column': 'Backlog',
         'committed_column': 'Committed',
-        'final_column': 'Test',
         'done_column': 'Done',
 
         'quantiles': [0.1, 0.2],
 
         'cycle_time_data': ['cycletime.csv'],
-        
+
         'ageing_wip_chart': 'ageing-wip.png',
         'ageing_wip_chart_title': 'Ageing WIP',
-        
+
         'burnup_window': 30,
         'burnup_chart': 'burnup.png',
         'burnup_chart_title': 'Burn-up',
-        
+
         'burnup_forecast_window': 30,
         'burnup_forecast_chart': 'burnup-forecast.png',
         'burnup_forecast_chart_deadline': datetime.date(2018, 6, 1),
@@ -282,35 +277,35 @@ Output:
         'burnup_forecast_chart_throughput_window_end': datetime.date(2018, 3, 1),
         'burnup_forecast_chart_title': 'Burn-up forecast',
         'burnup_forecast_chart_trials': 50,
-        
+
         'cfd_window': 30,
         'cfd_chart': 'cfd.png',
         'cfd_chart_title': 'Cumulative Flow Diagram',
         'cfd_data': ['cfd.csv'],
-        
+
         'histogram_window': 30,
         'histogram_chart': 'histogram.png',
         'histogram_chart_title': 'Cycle time histogram',
         'histogram_data': ['histogram.csv'],
-        
+
         'net_flow_frequency': '5D',
         'net_flow_window': 3,
         'net_flow_chart': 'net-flow.png',
         'net_flow_chart_title': 'Net flow',
-        
+
         'percentiles_data': ['percentiles.csv'],
-        
+
         'scatterplot_window': 30,
         'scatterplot_chart': 'scatterplot.png',
         'scatterplot_chart_title': 'Cycle time scatter plot',
         'scatterplot_data': ['scatterplot.csv'],
-        
+
         'throughput_frequency': '1D',
         'throughput_window': 3,
         'throughput_chart': 'throughput.png',
         'throughput_chart_title': 'Throughput trend',
         'throughput_data': ['throughput.csv'],
-        
+
         'wip_frequency': '3D',
         'wip_window': 3,
         'wip_chart': 'wip.png',
@@ -342,7 +337,7 @@ Output:
         'defects_by_type_chart_title': 'Defects by type',
         'defects_by_environment_chart': 'defects-by-environment.png',
         'defects_by_environment_chart_title': 'Defects by environment',
-        
+
         'debt_query': 'issueType = "Tech debt"',
         'debt_window': 3,
         'debt_priority_field': 'Priority',
@@ -450,8 +445,7 @@ Output:
         - 0.2
 
     Backlog column: Backlog
-    Committed column: Committed
-    Final column: Test
+    Committed column: In progress
     Done column: Done
 """)
 
@@ -482,16 +476,15 @@ Output:
 
         # overridden
         assert options['connection']['domain'] == 'https://bar.com'
-        
+
         # from extended base
         assert options['settings']['backlog_column'] == 'Backlog'
-        assert options['settings']['committed_column'] == 'Committed'
-        assert options['settings']['final_column'] == 'Test'
+        assert options['settings']['committed_column'] == 'In progress'
         assert options['settings']['done_column'] == 'Done'
 
         # from extending file
         assert options['settings']['cycle_time_data'] == ['cycletime.csv']
-        
+
         # overridden
         assert options['settings']['quantiles'] == [0.5, 0.7]
 

--- a/jira_agile_metrics/conftest.py
+++ b/jira_agile_metrics/conftest.py
@@ -83,18 +83,17 @@ def minimal_settings():
         'max_results': None,
         'verbose': False,
         'cycle': [
-            {'name': 'Backlog',   'statuses': ['Backlog'],           'type': 'backlog'},
-            {'name': 'Committed', 'statuses': ['Next'],              'type': 'accepted'},
-            {'name': 'Build',     'statuses': ['Build'],             'type': 'accepted'},
-            {'name': 'Test',      'statuses': ['Code review', 'QA'], 'type': 'accepted'},
-            {'name': 'Done',      'statuses': ['Done'],              'type': 'complete'}
+            {'name': 'Backlog',   'statuses': ['Backlog']},
+            {'name': 'Committed', 'statuses': ['Next']},
+            {'name': 'Build',     'statuses': ['Build']},
+            {'name': 'Test',      'statuses': ['Code review', 'QA']},
+            {'name': 'Done',      'statuses': ['Done']}
         ],
         'query_attribute': None,
         'queries': [{'jql': '(filter=123)', 'value': None}],
-        
+
         'backlog_column': 'Backlog',
         'committed_column': 'Committed',
-        'final_column': 'Test',
         'done_column': 'Done',
     }
 


### PR DESCRIPTION
While working with the ageing WIP chart I observed unexpected results when issues in Jira had skipped columns. Looking deeper into the issue I noticed that this also resulted in unexpected results in the calculation of cycle times. To demonstrate an correct the unexpected results I added two new tests:

- test_calculate_ageing_wip_with_skipped_columns in ageingwip_test
- test_movement_skipped_columns in cycletime_test

The change at hand corrects the results of both tests.

This is an updated pull request based on #24 and the feedback provided @rafalotufo in #23.