### PR TITLE
Add support for skipped columns

### DIFF
--- a/jira_agile_metrics/calculators/ageingwip_test.py
+++ b/jira_agile_metrics/calculators/ageingwip_test.py
@@ -143,10 +143,8 @@ def test_calculate_ageing_wip(query_manager, settings, results, today):
         {'key': 'A-12', 'status': 'Test', 'age': 8.0},
     ]
 
-def test_calculate_ageing_wip_with_different_columns(query_manager, settings, results, today):
+def test_calculate_ageing_wip_with_different_done_column(query_manager, settings, results, today):
     settings.update({
-        'committed_column': 'Committed',
-        'final_column': 'Build',
         'done_column': 'Test',
     })
 

--- a/jira_agile_metrics/calculators/cycletime.py
+++ b/jira_agile_metrics/calculators/cycletime.py
@@ -43,7 +43,7 @@ class CycleTimeCalculator(Calculator):
             self.query_manager,
             self.settings['cycle'],
             self.settings['attributes'],
-            self.settings['backlog_column'],
+            self.settings['committed_column'],
             self.settings['done_column'],
             self.settings['queries'],
             self.settings['query_attribute'],
@@ -52,7 +52,7 @@ class CycleTimeCalculator(Calculator):
 
     def write(self):
         output_files = self.settings['cycle_time_data']
-        
+
         if not output_files:
             logger.debug("No output file specified for cycle time data")
             return
@@ -83,7 +83,7 @@ def calculate_cycle_times(
     query_manager,
     cycle,                  # [{name:"", statuses:[""], type:""}]
     attributes,             # [{key:value}]
-    backlog_column,         # "" in `cycle`
+    committed_column,       # "" in `cycle`
     done_column,            # "" in `cycle`
     queries,                # [{jql:"", value:""}]
     query_attribute=None,   # ""
@@ -95,8 +95,7 @@ def calculate_cycle_times(
         now = datetime.datetime.utcnow()
 
     cycle_names = [s['name'] for s in cycle]
-    accepted_steps = set(s['name'] for s in cycle if s['type'] == StatusTypes.accepted)
-    completed_steps = set(s['name'] for s in cycle if s['type'] == StatusTypes.complete)
+    active_columns = cycle_names[cycle_names.index(committed_column):cycle_names.index(done_column)]
 
     cycle_lookup = {}
     for idx, cycle_step in enumerate(cycle):
@@ -104,7 +103,6 @@ def calculate_cycle_times(
             cycle_lookup[status.lower()] = dict(
                 index=idx,
                 name=cycle_step['name'],
-                type=cycle_step['type'],
             )
 
     unmapped_statuses = set()
@@ -169,7 +167,7 @@ def calculate_cycle_times(
                         logger.info("Issue %s transitioned to unknown JIRA status %s", issue.key, snapshot.to_string)
                         unmapped_statuses.add(snapshot.to_string)
                         continue
-                    
+
                     last_status = snapshot_cycle_step_name = snapshot_cycle_step['name']
 
                     # Keep the first time we entered a step
@@ -197,8 +195,8 @@ def calculate_cycle_times(
                         if impediment_start is None:
                             logger.warning("Issue %s had impediment flag cleared before being set. This should not happen.", issue.key)
                             continue
-                        
-                        if impediment_start_status not in (backlog_column, done_column):
+
+                        if impediment_start_status in active_columns:
                             item['blocked_days'] += (snapshot.date.date() - impediment_start).days
                         item['impediments'].append({
                             'start': impediment_start,
@@ -211,13 +209,13 @@ def calculate_cycle_times(
                         impediment_flag = None
                         impediment_start = None
                         impediment_start_status = None
-            
+
             # If an impediment flag was set but never cleared: treat as resolved on the ticket
             # resolution date if the ticket was resolved, else as still open until today.
             if impediment_start is not None:
                 if issue.fields.resolutiondate:
                     resolution_date = dateutil.parser.parse(issue.fields.resolutiondate).date()
-                    if impediment_start_status not in (backlog_column, done_column):
+                    if impediment_start_status in active_columns:
                         item['blocked_days'] += (resolution_date - impediment_start).days
                     item['impediments'].append({
                         'start': impediment_start,
@@ -226,7 +224,7 @@ def calculate_cycle_times(
                         'flag': impediment_flag,
                     })
                 else:
-                    if impediment_start_status not in (backlog_column, done_column):
+                    if impediment_start_status in active_columns:
                         item['blocked_days'] += (now.date() - impediment_start).days
                     item['impediments'].append({
                         'start': impediment_start,
@@ -237,25 +235,28 @@ def calculate_cycle_times(
                 impediment_flag = None
                 impediment_start = None
                 impediment_start_status = None
-            
-            # Wipe timestamps if items have moved backwards; calculate cycle time
+
+            # calculate cycle time
 
             previous_timestamp = None
-            accepted_timestamp = None
-            completed_timestamp = None
+            committed_timestamp = None
+            done_timestamp = None
 
-            for cycle_name in cycle_names:
+            for cycle_name in reversed(cycle_names):
                 if item[cycle_name] is not None:
                     previous_timestamp = item[cycle_name]
 
-                    if accepted_timestamp is None and previous_timestamp is not None and cycle_name in accepted_steps:
-                        accepted_timestamp = previous_timestamp
-                    if completed_timestamp is None and previous_timestamp is not None and cycle_name in completed_steps:
-                        completed_timestamp = previous_timestamp
+                if previous_timestamp is not None:
+                    item[cycle_name] = previous_timestamp
+                    if cycle_name == done_column:
+                        done_timestamp = previous_timestamp
+                    if cycle_name == committed_column:
+                        committed_timestamp = previous_timestamp
 
-            if accepted_timestamp is not None and completed_timestamp is not None:
-                item['cycle_time'] = completed_timestamp - accepted_timestamp
-                item['completed_timestamp'] = completed_timestamp
+            if committed_timestamp is not None and done_timestamp is not None:
+                item['cycle_time'] = done_timestamp - committed_timestamp
+                item['completed_timestamp'] = done_timestamp
+
 
             for k, v in item.items():
                 series[k]['data'].append(v)

--- a/jira_agile_metrics/calculators/cycletime_test.py
+++ b/jira_agile_metrics/calculators/cycletime_test.py
@@ -89,6 +89,43 @@ def jira(custom_fields):
     ])
 
 @pytest.fixture
+def jira_with_skipped_columns(custom_fields):
+    return JIRA(fields=custom_fields, issues=[
+        Issue("A-10",
+            summary="Gaps",
+            issuetype=Value("Story", "story"),
+            status=Value("Done", "done"),
+            resolution=Value("Done", "Done"),
+            resolutiondate="2018-01-04 01:01:01",
+            created="2018-01-01 01:01:01",
+            customfield_001="Team 1",
+            customfield_002=Value(None, 10),
+            customfield_003=Value(None, []),
+            customfield_100=None,
+            changes=[
+                Change("2018-01-02 01:05:01", [("status", "Backlog", "Next",)]),
+                Change("2018-01-04 01:01:01", [("status", "Next", "Done",), ("resolution", None, "done")]), # skipping columns Build and Test
+            ],
+        ),
+        Issue("A-11",
+            summary="More Gaps",
+            issuetype=Value("Story", "story"),
+            status=Value("Done", "done"),
+            resolution=Value("Done", "Done"),
+            resolutiondate="2018-01-04 01:01:01",
+            created="2018-01-01 01:01:01",
+            customfield_001="Team 1",
+            customfield_002=Value(None, 10),
+            customfield_003=Value(None, []),
+            customfield_100=None,
+            changes=[
+                Change("2018-01-02 01:05:01", [("status", "Backlog", "Build",)]),
+                Change("2018-01-04 01:01:01", [("status", "Build", "Done",), ("resolution", None, "done")]), # skipping columns Build and Test
+            ],
+        ),
+    ])
+
+@pytest.fixture
 def settings(custom_settings):
     return custom_settings
 
@@ -110,12 +147,12 @@ def test_columns(jira, settings):
         'Estimate',
         'Release',
         'Team',
-        
+
         'cycle_time',
         'completed_timestamp',
         'blocked_days',
         'impediments',
-        
+
         'Backlog',
         'Committed',
         'Build',
@@ -221,7 +258,7 @@ def test_movement(jira, settings):
         'Estimate': 30,
         'Release': 'None',
         'Team': 'Team 1',
-        
+
         'completed_timestamp': NaT,
         'cycle_time': NaT,
         'blocked_days': 3,
@@ -233,3 +270,57 @@ def test_movement(jira, settings):
         'Test': NaT,
         'Done': NaT,
     }]
+
+def test_movement_skipped_columns(jira_with_skipped_columns, settings):
+    query_manager = QueryManager(jira_with_skipped_columns, settings)
+    results = {}
+    calculator = CycleTimeCalculator(query_manager, settings, results)
+
+    data = calculator.run(now=datetime.datetime(2018, 1, 10, 15, 37, 0))
+
+    assert data.to_dict('records') == [{
+        'key': 'A-10',
+        'url': 'https://example.org/browse/A-10',
+        'issue_type': 'Story',
+        'summary': 'Gaps',
+        'status': 'Done',
+        'resolution': 'Done',
+
+        'Estimate': 10,
+        'Release': 'None',
+        'Team': 'Team 1',
+
+        'completed_timestamp': Timestamp('2018-01-04 00:00:00'),
+        'cycle_time': Timedelta('2 days 00:00:00'),
+        'blocked_days': 0,
+        'impediments': [],
+
+        'Backlog': Timestamp('2018-01-01 00:00:00'),
+        'Committed': Timestamp('2018-01-02 00:00:00'),
+        'Build': Timestamp('2018-01-04 00:00:00'),
+        'Test': Timestamp('2018-01-04 00:00:00'),
+        'Done': Timestamp('2018-01-04 00:00:00'),
+    }, {
+        'key': 'A-11',
+        'url': 'https://example.org/browse/A-11',
+        'issue_type': 'Story',
+        'summary': 'More Gaps',
+        'status': 'Done',
+        'resolution': 'Done',
+
+        'Estimate': 10,
+        'Release': 'None',
+        'Team': 'Team 1',
+
+        'completed_timestamp': Timestamp('2018-01-04 00:00:00'),
+        'cycle_time': Timedelta('2 days 00:00:00'),
+        'blocked_days': 0,
+        'impediments': [],
+
+        'Backlog': Timestamp('2018-01-01 00:00:00'),
+        'Committed': Timestamp('2018-01-02 00:00:00'),
+        'Build': Timestamp('2018-01-02 00:00:00'),
+        'Test': Timestamp('2018-01-04 00:00:00'),
+        'Done': Timestamp('2018-01-04 00:00:00'),
+    }]
+

--- a/jira_agile_metrics/calculators/impediments.py
+++ b/jira_agile_metrics/calculators/impediments.py
@@ -32,21 +32,23 @@ class ImpedimentsCalculator(Calculator):
         ):
             logger.debug("Not calculating impediments data as no output files specified")
             return None
-        
-        backlog_column = self.settings['backlog_column']
-        done_column = self.settings['done_column']
 
         cycle_data = self.get_result(CycleTimeCalculator)
         cycle_data = cycle_data[cycle_data.blocked_days > 0][['key', 'impediments']]
-        
+
         data = []
+
+        cycle_names = [s['name'] for s in self.settings['cycle']]
+        committed_column = self.settings['committed_column']
+        done_column = self.settings['done_column']
+        active_columns = cycle_names[cycle_names.index(committed_column):cycle_names.index(done_column)]
 
         for row in cycle_data.itertuples():
             for idx, event in enumerate(row.impediments):
                 # Ignore things that were impeded whilst in the backlog and/or done column
                 # (these are mostly nonsensical, and don't really indicate blocked/wasted time)
 
-                if event['status'] in (backlog_column, done_column):
+                if event['status'] not in active_columns:
                     continue
                 data.append({
                     'key': row.key,
@@ -55,7 +57,7 @@ class ImpedimentsCalculator(Calculator):
                     'start': pd.Timestamp(event['start']),
                     'end': pd.Timestamp(event['end']) if event['end'] else pd.NaT,
                 })
-        
+
         return pd.DataFrame(data, columns=['key', 'status', 'flag', 'start', 'end'])
 
     def write(self):
@@ -68,16 +70,16 @@ class ImpedimentsCalculator(Calculator):
 
         if self.settings['impediments_chart']:
             self.write_impediments_chart(data, self.settings['impediments_chart'])
-        
+
         if self.settings['impediments_days_chart']:
             self.write_impediments_days_chart(data, self.settings['impediments_days_chart'])
-        
+
         if self.settings['impediments_status_chart']:
             self.write_impediments_status_chart(data, self.settings['impediments_status_chart'])
-        
+
         if self.settings['impediments_status_days_chart']:
             self.write_impediments_status_days_chart(data, self.settings['impediments_status_days_chart'])
-    
+
     def write_data(self, data, output_files):
         for output_file in output_files:
             output_extension = get_extension(output_file)
@@ -94,10 +96,10 @@ class ImpedimentsCalculator(Calculator):
         if len(chart_data.index) == 0:
             logger.warning("Cannot draw impediments chart with zero items")
             return
-        
+
         window = self.settings['impediments_window']
         breakdown = breakdown_by_month(chart_data, 'start', 'end', 'key', 'flag')
-        
+
         if window:
             breakdown = breakdown[-window:]
 
@@ -106,9 +108,9 @@ class ImpedimentsCalculator(Calculator):
             return
 
         fig, ax = plt.subplots()
-        
+
         breakdown.plot.bar(ax=ax, stacked=True)
-        
+
         if self.settings['impediments_chart_title']:
             ax.set_title(self.settings['impediments_chart_title'])
 
@@ -125,7 +127,7 @@ class ImpedimentsCalculator(Calculator):
         logger.info("Writing impediments chart to %s", output_file)
         fig.savefig(output_file, bbox_inches='tight', dpi=300)
         plt.close(fig)
-    
+
     def write_impediments_days_chart(self, chart_data, output_file):
         if len(chart_data.index) == 0:
             logger.warning("Cannot draw impediments days chart with zero items")
@@ -133,7 +135,7 @@ class ImpedimentsCalculator(Calculator):
 
         window = self.settings['impediments_window']
         breakdown = breakdown_by_month_sum_days(chart_data, 'start', 'end', 'flag')
-        
+
         if window:
             breakdown = breakdown[-window:]
 
@@ -142,9 +144,9 @@ class ImpedimentsCalculator(Calculator):
             return
 
         fig, ax = plt.subplots()
-        
+
         breakdown.plot.bar(ax=ax, stacked=True)
-        
+
         if self.settings['impediments_days_chart_title']:
             ax.set_title(self.settings['impediments_days_chart_title'])
 
@@ -161,17 +163,17 @@ class ImpedimentsCalculator(Calculator):
         logger.info("Writing impediments days chart to %s", output_file)
         fig.savefig(output_file, bbox_inches='tight', dpi=300)
         plt.close(fig)
-    
+
     def write_impediments_status_chart(self, chart_data, output_file):
         if len(chart_data.index) == 0:
             logger.warning("Cannot draw impediments status chart with zero items")
             return
-        
+
         window = self.settings['impediments_window']
         cycle_names = [s['name'] for s in self.settings['cycle']]
 
         breakdown = breakdown_by_month(chart_data, 'start', 'end', 'key', 'status', cycle_names)
-        
+
         if window:
             breakdown = breakdown[-window:]
 
@@ -180,9 +182,9 @@ class ImpedimentsCalculator(Calculator):
             return
 
         fig, ax = plt.subplots()
-        
+
         breakdown.plot.bar(ax=ax, stacked=True)
-        
+
         if self.settings['impediments_status_chart_title']:
             ax.set_title(self.settings['impediments_status_chart_title'])
 
@@ -199,7 +201,7 @@ class ImpedimentsCalculator(Calculator):
         logger.info("Writing impediments status chart to %s", output_file)
         fig.savefig(output_file, bbox_inches='tight', dpi=300)
         plt.close(fig)
-    
+
     def write_impediments_status_days_chart(self, chart_data, output_file):
         if len(chart_data.index) == 0:
             logger.warning("Cannot draw impediments status days chart with zero items")
@@ -209,7 +211,7 @@ class ImpedimentsCalculator(Calculator):
         cycle_names = [s['name'] for s in self.settings['cycle']]
 
         breakdown = breakdown_by_month_sum_days(chart_data, 'start', 'end', 'status', cycle_names)
-        
+
         if window:
             breakdown = breakdown[-window:]
 
@@ -218,9 +220,9 @@ class ImpedimentsCalculator(Calculator):
             return
 
         fig, ax = plt.subplots()
-        
+
         breakdown.plot.bar(ax=ax, stacked=True)
-        
+
         if self.settings['impediments_status_days_chart_title']:
             ax.set_title(self.settings['impediments_status_days_chart_title'])
 

--- a/jira_agile_metrics/calculators/impediments_test.py
+++ b/jira_agile_metrics/calculators/impediments_test.py
@@ -50,7 +50,7 @@ def cycle_time_results(minimal_cycle_time_columns):
             ]),
         ]), columns=minimal_cycle_time_columns)
     }
-    
+
 def test_only_runs_if_charts_set(query_manager, settings, cycle_time_results):
     test_settings = extend_dict(settings, {
         'impediments_data': None,
@@ -155,13 +155,13 @@ def test_calculate_impediments(query_manager, settings, cycle_time_results):
 def test_different_backlog_column(query_manager, settings, cycle_time_results):
     settings = extend_dict(settings, {
         'backlog_column': 'Committed',
+        'committed_column': 'Build',
     })
     calculator = ImpedimentsCalculator(query_manager, settings, cycle_time_results)
 
     data = calculator.run()
 
     assert data.to_dict('records') == [
-        {'key': 'A-2', 'status': 'Backlog', 'flag': 'Impediment', 'start': _ts('2018-01-05'), 'end': _ts('2018-01-07')},
         {'key': 'A-3', 'status': 'Build',   'flag': 'Impediment', 'start': _ts('2018-01-04'), 'end': _ts('2018-01-05')},
     ]
 
@@ -175,6 +175,5 @@ def test_different_done_column(query_manager, settings, cycle_time_results):
 
     assert data.to_dict('records') == [
         {'key': 'A-2', 'status': 'Committed', 'flag': 'Impediment',     'start': _ts('2018-01-10'), 'end': _ts('2018-01-12')},
-        {'key': 'A-3', 'status': 'Done',      'flag': 'Impediment',     'start': _ts('2018-01-07'), 'end': _ts('2018-01-10')},
         {'key': 'A-4', 'status': 'Committed', 'flag': 'Awaiting input', 'start': _ts('2018-01-05'), 'end': NaT},
     ]

--- a/jira_agile_metrics/calculators/waste_test.py
+++ b/jira_agile_metrics/calculators/waste_test.py
@@ -161,13 +161,12 @@ def test_query(jira, settings):
     assert data.to_dict('records') == [
         {'key': 'A-1', 'last_status': 'Test',      'resolution': 'Withdrawn', 'withdrawn_date': Timestamp('2018-01-06 02:02:02')},
         {'key': 'A-2', 'last_status': 'Committed', 'resolution': 'Withdrawn', 'withdrawn_date': Timestamp('2018-01-07 02:02:02')},
-        {'key': 'A-6', 'last_status': 'foobar',    'resolution': 'Withdrawn', 'withdrawn_date': Timestamp('2018-01-06 02:02:02')},
-        {'key': 'A-7', 'last_status': None,        'resolution': 'Withdrawn', 'withdrawn_date': Timestamp('2018-01-06 02:02:02')},
     ]
 
 def test_different_backlog_column(jira, settings):
     settings = extend_dict(settings, {
-        'backlog_column': 'Committed'
+        'backlog_column': 'Committed',
+        'committed_column': 'Build',
     })
 
     query_manager = QueryManager(jira, settings)
@@ -178,9 +177,6 @@ def test_different_backlog_column(jira, settings):
 
     assert data.to_dict('records') == [
         {'key': 'A-1', 'last_status': 'Test',      'resolution': 'Withdrawn', 'withdrawn_date': Timestamp('2018-01-06 02:02:02')},
-        {'key': 'A-4', 'last_status': 'Backlog',   'resolution': 'Withdrawn', 'withdrawn_date': Timestamp('2018-01-09 02:02:02')},
-        {'key': 'A-6', 'last_status': 'foobar',    'resolution': 'Withdrawn', 'withdrawn_date': Timestamp('2018-01-06 02:02:02')},
-        {'key': 'A-7', 'last_status': None,        'resolution': 'Withdrawn', 'withdrawn_date': Timestamp('2018-01-06 02:02:02')},
     ]
 
 def test_different_done_column(jira, settings):
@@ -196,7 +192,4 @@ def test_different_done_column(jira, settings):
 
     assert data.to_dict('records') == [
         {'key': 'A-2', 'last_status': 'Committed', 'resolution': 'Withdrawn', 'withdrawn_date': Timestamp('2018-01-07 02:02:02')},
-        {'key': 'A-3', 'last_status': 'Done',      'resolution': 'Withdrawn', 'withdrawn_date': Timestamp('2018-01-08 02:02:02')},
-        {'key': 'A-6', 'last_status': 'foobar',    'resolution': 'Withdrawn', 'withdrawn_date': Timestamp('2018-01-06 02:02:02')},
-        {'key': 'A-7', 'last_status': None,        'resolution': 'Withdrawn', 'withdrawn_date': Timestamp('2018-01-06 02:02:02')},
     ]

--- a/jira_agile_metrics/calculators/wip.py
+++ b/jira_agile_metrics/calculators/wip.py
@@ -17,18 +17,11 @@ class WIPChartCalculator(Calculator):
         cfd_data = self.get_result(CFDCalculator)
         cycle_names = [s['name'] for s in self.settings['cycle']]
 
-        start_column = self.settings['committed_column']
+        committed_column = self.settings['committed_column']
         done_column = self.settings['done_column']
 
-        if start_column not in cycle_names:
-            logger.error("Committed column %s does not exist", start_column)
-            return None
-        if done_column not in cycle_names:
-            logger.error("Done column %s does not exist", done_column)
-            return None
-        
-        return pd.DataFrame({'wip': cfd_data[start_column] - cfd_data[done_column]}, index=cfd_data.index)
-    
+        return pd.DataFrame({'wip': cfd_data[committed_column] - cfd_data[done_column]}, index=cfd_data.index)
+
     def write(self):
         output_file = self.settings['wip_chart']
         if not output_file:
@@ -42,7 +35,7 @@ class WIPChartCalculator(Calculator):
             return
 
         fig, ax = plt.subplots()
-        
+
         if self.settings['wip_chart_title']:
             ax.set_title(self.settings['wip_chart_title'])
 

--- a/jira_agile_metrics/config.py
+++ b/jira_agile_metrics/config.py
@@ -111,7 +111,7 @@ def config_to_options(data, cwd=None, extended=False):
         config = ordered_load(data, yaml.SafeLoader)
     except Exception:
         raise ConfigError("Unable to parse YAML configuration file.") from None
-    
+
     if config is None:
         raise ConfigError("Configuration file is empty") from None
 
@@ -133,12 +133,11 @@ def config_to_options(data, cwd=None, extended=False):
             'cycle': [],
             'max_results': None,
             'verbose': False,
-        
+
             'quantiles': [0.5, 0.85, 0.95],
 
             'backlog_column': None,
             'committed_column': None,
-            'final_column': None,
             'done_column': None,
 
             'cycle_time_data': None,
@@ -148,7 +147,7 @@ def config_to_options(data, cwd=None, extended=False):
             'scatterplot_data': None,
             'scatterplot_chart': None,
             'scatterplot_chart_title': None,
-            
+
             'histogram_window': None,
             'histogram_data': None,
             'histogram_chart': None,
@@ -158,13 +157,13 @@ def config_to_options(data, cwd=None, extended=False):
             'cfd_data': None,
             'cfd_chart': None,
             'cfd_chart_title': None,
-            
+
             'throughput_frequency': '1W-MON',
             'throughput_window': None,
             'throughput_data': None,
             'throughput_chart': None,
             'throughput_chart_title': None,
-            
+
             'burnup_window': None,
             'burnup_chart': None,
             'burnup_chart_title': None,
@@ -202,7 +201,7 @@ def config_to_options(data, cwd=None, extended=False):
             'impediments_status_chart_title': None,
             'impediments_status_days_chart': None,
             'impediments_status_days_chart_title': None,
-            
+
             'defects_query': None,
             'defects_window': None,
             'defects_priority_field': None,
@@ -218,7 +217,7 @@ def config_to_options(data, cwd=None, extended=False):
             'defects_by_type_chart_title': None,
             'defects_by_environment_chart': None,
             'defects_by_environment_chart_title': None,
-        
+
             'debt_query': None,
             'debt_window': None,
             'debt_priority_field': None,
@@ -260,7 +259,7 @@ def config_to_options(data, cwd=None, extended=False):
 
         if not os.path.exists(extends_filename):
             raise ConfigError("File `%s` referenced in `extends` not found." % extends_filename) from None
-        
+
         logger.debug("Extending file %s" % extends_filename)
         with open(extends_filename) as extends_file:
             options = config_to_options(extends_file.read(), cwd=os.path.dirname(extends_filename), extended=True)
@@ -277,10 +276,10 @@ def config_to_options(data, cwd=None, extended=False):
 
         if 'password' in config['connection']:
             options['connection']['password'] = config['connection']['password']
-        
+
         if 'http proxy' in config['connection']:
             options['connection']['http_proxy'] = config['connection']['http proxy']
-        
+
         if 'https proxy' in config['connection']:
             options['connection']['https_proxy'] = config['connection']['https proxy']
 
@@ -319,7 +318,7 @@ def config_to_options(data, cwd=None, extended=False):
         ]:
             if expand_key(key) in config['output']:
                 options['settings'][key] = force_int(key, config['output'][expand_key(key)])
-        
+
         # float values
         for key in [
             'burnup_forecast_chart_deadline_confidence',
@@ -334,7 +333,7 @@ def config_to_options(data, cwd=None, extended=False):
         ]:
             if expand_key(key) in config['output']:
                 options['settings'][key] = force_date(key, config['output'][expand_key(key)])
-        
+
         # file name values
         for key in [
             'scatterplot_chart',
@@ -360,7 +359,7 @@ def config_to_options(data, cwd=None, extended=False):
         ]:
             if expand_key(key) in config['output']:
                 options['settings'][key] = os.path.basename(config['output'][expand_key(key)])
-        
+
         # file name list values
         for key in [
             'cycle_time_data',
@@ -369,7 +368,7 @@ def config_to_options(data, cwd=None, extended=False):
             'histogram_data',
             'throughput_data',
             'percentiles_data',
-            
+
             'impediments_data',
         ]:
             if expand_key(key) in config['output']:
@@ -390,7 +389,6 @@ def config_to_options(data, cwd=None, extended=False):
         for key in [
             'backlog_column',
             'committed_column',
-            'final_column',
             'done_column',
             'throughput_frequency',
             'scatterplot_chart_title',
@@ -464,24 +462,52 @@ def config_to_options(data, cwd=None, extended=False):
     if 'workflow' in config:
         if len(config['workflow'].keys()) < 3:
             raise ConfigError("`Workflow` section must contain at least three statuses")
-        
-        options['settings']['cycle'] = [{
-            "name": name,
-            "type": StatusTypes.accepted,
-            "statuses": force_list(statuses)
-        } for name, statuses in config['workflow'].items()]
 
-        options['settings']['cycle'][0]['type'] = StatusTypes.backlog
-        options['settings']['cycle'][-1]['type'] = StatusTypes.complete
+        column_names = []
+        for name, statuses in config['workflow'].items():
+            statuses = force_list(statuses)
+            options['settings']['cycle'].append({
+                "name": name,
+                "statuses": statuses
+            })
+            column_names.append(name)
 
         if options['settings']['backlog_column'] is None:
-            options['settings']['backlog_column'] = options['settings']['cycle'][0]['name']
-        if options['settings']['committed_column'] is None:
-            options['settings']['committed_column'] = options['settings']['cycle'][1]['name']
-        if options['settings']['final_column'] is None:
-            options['settings']['final_column'] = options['settings']['cycle'][-2]['name']
+            if options['settings']['committed_column'] is None:
+                options['settings']['backlog_column'] = column_names[0]
+                logger.info("`Backlog column` automatically set to `%s`", options['settings']['backlog_column'])
+                options['settings']['committed_column'] = column_names[1]
+                logger.info("`Committed column` automatically set to `%s`", options['settings']['committed_column'])
+            else:
+                if options['settings']['committed_column'] not in column_names:
+                    raise ConfigError("`Committed column` (%s) must exist in `Workflow`: %s" % (options['settings']['committed_column'], column_names))
+                elif column_names.index(options['settings']['committed_column']) > 0:
+                     options['settings']['backlog_column'] = column_names[column_names.index(options['settings']['committed_column'])-1]
+                     logger.info("`Backlog column` automatically set to `%s`", options['settings']['backlog_column'])
+                else:
+                    raise ConfigError("There must be at least 1 column before `Committed column` (%s) in `Workflow`: %s" % (options['settings']['committed_column'], column_names))
+        else:
+            if options['settings']['backlog_column'] not in column_names:
+                raise ConfigError("`Backlog column` (%s) must exist in `Workflow`: %s" % (options['settings']['backlog_column'], column_names))
+            elif column_names.index(options['settings']['backlog_column']) < (len(column_names)-2):
+                options['settings']['committed_column'] = column_names[column_names.index(options['settings']['backlog_column'])+1]
+                logger.info("`Committed column` automatically set to `%s`", options['settings']['committed_column'])
+            else:
+                raise ConfigError("There must be at least 2 columns after `Backlog column` (%s) in `Workflow`: %s" % (options['settings']['committed_column'], column_names))
+
         if options['settings']['done_column'] is None:
-            options['settings']['done_column'] = options['settings']['cycle'][-1]['name']
+            options['settings']['done_column'] = column_names[-1]
+            logger.info("`Done column` automatically set to `%s`", options['settings']['done_column'])
+        elif options['settings']['done_column'] not in column_names:
+            raise ConfigError("`Done column` (%s) must exist in `Workflow`: %s" % (options['settings']['done_column'], column_names))
+
+        # backlog column must come before committed column
+        if not (column_names.index(options['settings']['backlog_column'])+1) == column_names.index(options['settings']['committed_column']):
+            raise ConfigError("`Backlog column` (%s) must come immediately before `Committed column` (%s) in `Workflow`" % (options['settings']['backlog_column'], options['settings']['committed_column']))
+
+        # committed column must come before done column
+        if not column_names.index(options['settings']['committed_column']) < column_names.index(options['settings']['done_column']):
+            raise ConfigError("`Committed column` (%s) must come before `Done column` (%s) in `Workflow`: %s" % (options['settings']['committed_column'], options['settings']['done_column'], column_names))
 
     # Make sure we have workflow (but only if this file is not being extended by another)
     if not extended and len(options['settings']['cycle']) == 0:

--- a/jira_agile_metrics/config_test.py
+++ b/jira_agile_metrics/config_test.py
@@ -40,9 +40,8 @@ Workflow:
 
     assert options['settings']['backlog_column'] == 'Backlog'
     assert options['settings']['committed_column'] == 'In progress'
-    assert options['settings']['final_column'] == 'In progress'
     assert options['settings']['done_column'] == 'Done'
-    
+
 
 def test_config_to_options_maximal():
 
@@ -89,17 +88,16 @@ Output:
 
     Backlog column: Backlog
     Committed column: Committed
-    Final column: Test
     Done column: Done
 
     Cycle time data: cycletime.csv
     Percentiles data: percentiles.csv
-    
+
     Scatterplot window: 30
     Scatterplot data: scatterplot.csv
     Scatterplot chart: scatterplot.png
     Scatterplot chart title: Cycle time scatter plot
-    
+
     Histogram window: 30
     Histogram chart: histogram.png
     Histogram chart title: Cycle time histogram
@@ -110,7 +108,7 @@ Output:
     CFD chart title: Cumulative Flow Diagram
 
     Histogram data: histogram.csv
-    
+
     Throughput frequency: 1D
     Throughput window: 3
     Throughput data: throughput.csv
@@ -178,7 +176,7 @@ Output:
     Defects by type chart title: Defects by type
     Defects by environment chart: defects-by-environment.png
     Defects by environment chart title: Defects by environment
-    
+
     Debt query: issueType = "Tech debt"
     Debt window: 3
     Debt priority field: Priority
@@ -236,16 +234,14 @@ Output:
         'https_proxy': 'https://proxy2.local',
         'jira_server_version_check': True
     }
-   
+
     assert options['settings'] == {
         'cycle': [
-            {'name': 'Backlog', 'statuses': ['Backlog'], 'type': 'backlog'},
-            {'name': 'Committed', 'statuses': ['Next'], 'type': 'accepted'},
-            {'name': 'Build', 'statuses': ['Build'], 'type': 'accepted'},
-            {'name': 'Test',
-                'statuses': ['Code review', 'QA'],
-                'type': 'accepted'},
-            {'name': 'Done', 'statuses': ['Done'], 'type': 'complete'}
+            {'name': 'Backlog', 'statuses': ['Backlog']},
+            {'name': 'Committed', 'statuses': ['Next']},
+            {'name': 'Build', 'statuses': ['Build']},
+            {'name': 'Test', 'statuses': ['Code review', 'QA']},
+            {'name': 'Done', 'statuses': ['Done']}
         ],
 
         'attributes': {'Release': 'Fix version/s', 'Team': 'Team'},
@@ -256,23 +252,22 @@ Output:
         'queries': [{'jql': '(filter=123)', 'value': 'Team 1'},
                     {'jql': '(filter=124)', 'value': 'Team 2'}],
         'query_attribute': 'Team',
-                
+
         'backlog_column': 'Backlog',
         'committed_column': 'Committed',
-        'final_column': 'Test',
         'done_column': 'Done',
 
         'quantiles': [0.1, 0.2],
 
         'cycle_time_data': ['cycletime.csv'],
-        
+
         'ageing_wip_chart': 'ageing-wip.png',
         'ageing_wip_chart_title': 'Ageing WIP',
-        
+
         'burnup_window': 30,
         'burnup_chart': 'burnup.png',
         'burnup_chart_title': 'Burn-up',
-        
+
         'burnup_forecast_window': 30,
         'burnup_forecast_chart': 'burnup-forecast.png',
         'burnup_forecast_chart_deadline': datetime.date(2018, 6, 1),
@@ -282,35 +277,35 @@ Output:
         'burnup_forecast_chart_throughput_window_end': datetime.date(2018, 3, 1),
         'burnup_forecast_chart_title': 'Burn-up forecast',
         'burnup_forecast_chart_trials': 50,
-        
+
         'cfd_window': 30,
         'cfd_chart': 'cfd.png',
         'cfd_chart_title': 'Cumulative Flow Diagram',
         'cfd_data': ['cfd.csv'],
-        
+
         'histogram_window': 30,
         'histogram_chart': 'histogram.png',
         'histogram_chart_title': 'Cycle time histogram',
         'histogram_data': ['histogram.csv'],
-        
+
         'net_flow_frequency': '5D',
         'net_flow_window': 3,
         'net_flow_chart': 'net-flow.png',
         'net_flow_chart_title': 'Net flow',
-        
+
         'percentiles_data': ['percentiles.csv'],
-        
+
         'scatterplot_window': 30,
         'scatterplot_chart': 'scatterplot.png',
         'scatterplot_chart_title': 'Cycle time scatter plot',
         'scatterplot_data': ['scatterplot.csv'],
-        
+
         'throughput_frequency': '1D',
         'throughput_window': 3,
         'throughput_chart': 'throughput.png',
         'throughput_chart_title': 'Throughput trend',
         'throughput_data': ['throughput.csv'],
-        
+
         'wip_frequency': '3D',
         'wip_window': 3,
         'wip_chart': 'wip.png',
@@ -342,7 +337,7 @@ Output:
         'defects_by_type_chart_title': 'Defects by type',
         'defects_by_environment_chart': 'defects-by-environment.png',
         'defects_by_environment_chart_title': 'Defects by environment',
-        
+
         'debt_query': 'issueType = "Tech debt"',
         'debt_window': 3,
         'debt_priority_field': 'Priority',
@@ -450,8 +445,7 @@ Output:
         - 0.2
 
     Backlog column: Backlog
-    Committed column: Committed
-    Final column: Test
+    Committed column: In progress
     Done column: Done
 """)
 
@@ -482,16 +476,15 @@ Output:
 
         # overridden
         assert options['connection']['domain'] == 'https://bar.com'
-        
+
         # from extended base
         assert options['settings']['backlog_column'] == 'Backlog'
-        assert options['settings']['committed_column'] == 'Committed'
-        assert options['settings']['final_column'] == 'Test'
+        assert options['settings']['committed_column'] == 'In progress'
         assert options['settings']['done_column'] == 'Done'
 
         # from extending file
         assert options['settings']['cycle_time_data'] == ['cycletime.csv']
-        
+
         # overridden
         assert options['settings']['quantiles'] == [0.5, 0.7]
 
@@ -523,7 +516,6 @@ Output:
 
     Backlog column: Backlog
     Committed column: Committed
-    Final column: Test
     Done column: Done
 """)
 

--- a/jira_agile_metrics/conftest.py
+++ b/jira_agile_metrics/conftest.py
@@ -83,18 +83,17 @@ def minimal_settings():
         'max_results': None,
         'verbose': False,
         'cycle': [
-            {'name': 'Backlog',   'statuses': ['Backlog'],           'type': 'backlog'},
-            {'name': 'Committed', 'statuses': ['Next'],              'type': 'accepted'},
-            {'name': 'Build',     'statuses': ['Build'],             'type': 'accepted'},
-            {'name': 'Test',      'statuses': ['Code review', 'QA'], 'type': 'accepted'},
-            {'name': 'Done',      'statuses': ['Done'],              'type': 'complete'}
+            {'name': 'Backlog',   'statuses': ['Backlog']},
+            {'name': 'Committed', 'statuses': ['Next']},
+            {'name': 'Build',     'statuses': ['Build']},
+            {'name': 'Test',      'statuses': ['Code review', 'QA']},
+            {'name': 'Done',      'statuses': ['Done']}
         ],
         'query_attribute': None,
         'queries': [{'jql': '(filter=123)', 'value': None}],
-        
+
         'backlog_column': 'Backlog',
         'committed_column': 'Committed',
-        'final_column': 'Test',
         'done_column': 'Done',
     }
 


### PR DESCRIPTION
Based on the feedback from @optilude and @rlotufo for #24 and #26 I refactored the code that is supposed to add support for skipped columns. I have refactored `cycletime.py` so that it calculates the correct timestamp for skipped columns, mimicking the behaviour of ActionableAgile Analytics. This makes calculations in subsequent calculators much easier, because they do no't have to handle these special cases anymore.

I also refactored a small part of `config.py` to perform some basic checks on the `Workflow` settings:

- The `Backlog column` has to be the column immediately preceding the `Committed column`
- There must at least one column after the `Committed column`, that is the `Done column`

All unit tests run without issues and I have already tested with different Jira setups I have in production.