### PR TITLE
Don't eat YAML exceptions as otherwise you are unable to locate parse…

### DIFF
--- a/jira_agile_metrics/config.py
+++ b/jira_agile_metrics/config.py
@@ -109,8 +109,8 @@ def to_progress_report_outcomes_list(value):
 def config_to_options(data, cwd=None, extended=False):
     try:
         config = ordered_load(data, yaml.SafeLoader)
-    except Exception:
-        raise ConfigError("Unable to parse YAML configuration file.") from None
+    except Exception as e:
+        raise ConfigError("Unable to parse YAML configuration file.") from e
 
     if config is None:
         raise ConfigError("Configuration file is empty") from None


### PR DESCRIPTION
Don't eat YAML exceptions as otherwise, you are unable to locate pars errors in yml source and fix your config files.

Example YAML parse error:

```
yaml.parser.ParserError: while parsing a block mapping
  in "<unicode string>", line 2, column 1:
    Extends: common.yaml
    ^
expected <block end>, but found ']'
  in "<unicode string>", line 3, column 1:
    ]
    ^
```