### PR TITLE
[WIP] Add supports for backwards transitions

### DIFF
--- a/jira_agile_metrics/calculators/cycletime.py
+++ b/jira_agile_metrics/calculators/cycletime.py
@@ -182,7 +182,7 @@ def calculate_cycle_times(
             # Record date of status and impediments flag changes
             for snapshot in query_manager.iter_changes(issue, ['status', 'Flagged']):
 
-                logger.debug("Moving issue %s to state %s", issue.key, snapshot.to_string)
+                logger.debug("Moving issue %s to state %s, item is %s", issue.key, snapshot.to_string, item)
 
                 if snapshot.change == 'status':
                     snapshot_cycle_step = cycle_lookup.get(snapshot.to_string.lower(), None)

--- a/jira_agile_metrics/calculators/cycletime.py
+++ b/jira_agile_metrics/calculators/cycletime.py
@@ -11,7 +11,7 @@ from ..utils import get_extension, to_json_string, StatusTypes
 logger = logging.getLogger(__name__)
 
 
-class BackwardsTransitionHandling:
+class BackwardsTransitionHandling(Enum):
     """How to handle backwards movement in the state graph."""
 
     #: When an issue re-enters a state, the previous
@@ -20,7 +20,7 @@ class BackwardsTransitionHandling:
 
     #: When an issue re-enters a state, the new
     #: time spent on the
-    accumulate = "accumualate"
+    accumulate = "accumulate"
 
 
 class CycleTimeCalculator(Calculator):
@@ -61,8 +61,8 @@ class CycleTimeCalculator(Calculator):
             self.settings['done_column'],
             self.settings['queries'],
             self.settings['query_attribute'],
-            BackwardsTransitionHandling(self.settings['backwards_transitions']),
-            now=now
+            now=now,
+            backwards_transitions=BackwardsTransitionHandling(self.settings['backwards_transitions']),
             )
 
     def write(self):
@@ -101,9 +101,9 @@ def calculate_cycle_times(
     committed_column,       # "" in `cycle`
     done_column,            # "" in `cycle`
     queries,                # [{jql:"", value:""}]
-    backwards_transitions: BackwardsTransitionHandling=None,
     query_attribute=None,   # ""
-    now=None
+    now=None,
+    backwards_transitions: BackwardsTransitionHandling=None,
 ):
 
     # Allows unit testing to use a fixed date

--- a/jira_agile_metrics/cli.py
+++ b/jira_agile_metrics/cli.py
@@ -24,7 +24,7 @@ def configure_argument_parser():
     parser.add_argument('-v', dest='verbose', action='store_true', help='Verbose output')
     parser.add_argument('-vv', dest='very_verbose', action='store_true', help='Even more verbose output')
     parser.add_argument('-n', metavar='N', dest='max_results', type=int, help='Only fetch N most recently updated issues')
-    
+
     parser.add_argument('--server', metavar='127.0.0.1:8080', help='Run as a web server instead of a command line tool, on the given host and/or port. The remaining options do not apply.')
 
     # Output directory
@@ -37,7 +37,7 @@ def configure_argument_parser():
     parser.add_argument('--http-proxy', metavar='https://proxy.local', help='URL to HTTP Proxy')
     parser.add_argument('--https-proxy', metavar='https://proxy.local', help='URL to HTTPS Proxy')
     parser.add_argument('--jira-server-version-check', type=bool, metavar='True', help='If true it will fetch JIRA server version info first to determine if some API calls are available')
-    
+
     return parser
 
 def main():
@@ -52,7 +52,7 @@ def main():
 def run_server(parser, args):
     host = None
     port = args.server
-    
+
     if ':' in args.server:
         (host, port) = args.server.split(':')
     port = int(port)
@@ -64,7 +64,7 @@ def run_command_line(parser, args):
     if not args.config:
         parser.print_usage()
         return
-    
+
     logging.basicConfig(
         format='[%(asctime)s %(levelname)s] %(message)s',
         datefmt='%Y-%m-%d %H:%M:%S',

--- a/jira_agile_metrics/config.py
+++ b/jira_agile_metrics/config.py
@@ -133,6 +133,7 @@ def config_to_options(data, cwd=None, extended=False):
             'cycle': [],
             'max_results': None,
             'verbose': False,
+            'backwards_transitions': "reset",
 
             'quantiles': [0.5, 0.85, 0.95],
 
@@ -390,6 +391,7 @@ def config_to_options(data, cwd=None, extended=False):
             'backlog_column',
             'committed_column',
             'done_column',
+            'backwards_transitions',
             'throughput_frequency',
             'scatterplot_chart_title',
             'histogram_chart_title',
@@ -521,5 +523,8 @@ def config_to_options(data, cwd=None, extended=False):
     if 'known values' in config:
         for name, values in config['known values'].items():
             options['settings']['known_values'][name] = force_list(values)
+
+    if 'backwards_transitions' in config:
+        options['settings']['backwards_transitions'] = config['backwards_transitions']
 
     return options

--- a/jira_agile_metrics/config.py
+++ b/jira_agile_metrics/config.py
@@ -524,7 +524,7 @@ def config_to_options(data, cwd=None, extended=False):
         for name, values in config['known values'].items():
             options['settings']['known_values'][name] = force_list(values)
 
-    if 'backwards_transitions' in config:
-        options['settings']['backwards_transitions'] = config['backwards_transitions']
+    if 'backwards transitions' in config:
+        options['settings']['backwards_transitions'] = config['backwards transitions']
 
     return options

--- a/jira_agile_metrics/config_test.py
+++ b/jira_agile_metrics/config_test.py
@@ -66,6 +66,8 @@ Attributes:
     Team: Team
     Release: Fix version/s
 
+Backwards transitions: accumulate
+
 Known values:
     Release:
         - "R01"
@@ -89,6 +91,8 @@ Output:
     Backlog column: Backlog
     Committed column: Committed
     Done column: Done
+
+    Backwards transitions: accumulate
 
     Cycle time data: cycletime.csv
     Percentiles data: percentiles.csv
@@ -256,6 +260,8 @@ Output:
         'backlog_column': 'Backlog',
         'committed_column': 'Committed',
         'done_column': 'Done',
+
+        'backwards_transitions': "accumulate",
 
         'quantiles': [0.1, 0.2],
 

--- a/jira_agile_metrics/conftest.py
+++ b/jira_agile_metrics/conftest.py
@@ -95,6 +95,7 @@ def minimal_settings():
         'backlog_column': 'Backlog',
         'committed_column': 'Committed',
         'done_column': 'Done',
+        'backwards_transitions': 'reset',
     }
 
 
@@ -108,6 +109,7 @@ def custom_settings(minimal_settings):
             'Team': 'Team',
             'Estimate': 'Size'
         },
+        'backwards_transitions': 'reset',
         'known_values': {
             'Release': ['R1', 'R3']
         },

--- a/jira_agile_metrics/utils.py
+++ b/jira_agile_metrics/utils.py
@@ -143,6 +143,12 @@ class Timespans:
     - QA
     - QA fixes needed
     - QA (again)
+    - QA fixes needed (again)
+    - QA (third time)
+
+    Remarks:
+
+    - Spans can have zero duration, but not negative duration
     """
 
     def __init__(self):
@@ -151,20 +157,22 @@ class Timespans:
         # If the closing datetime is missing the item was never closed
         self.spans = []  #: List[List[datetime)]
 
-    def __str__(self):
-        """Produce a nice readable format of spans.
+    def reset(self):
+        """Used by state backwards transition tracking logic."""
+        self.spans = []
 
-        We assume this class is used to deal with dates, so we discard hours part."""
+    def __str__(self):
+        """Produce a nice readable format of spans."""
         out = ""
-        elems = list(self.spans)
         # https://stackoverflow.com/a/49486415/315168
+        elems = list(self.spans)
         while elems:
             s = elems.pop(0)
-            out += s[0].strftime("%Y-%m-%d")
+            out += s[0].strftime("%Y-%m-%d %H:%M")
             out += " - "
             if len(s) == 2:
                 # Span has end
-                out += s[1].strftime("%Y-%m-%d")
+                out += s[1].strftime("%Y-%m-%d %H:%M")
             if elems:
                 # Not last elements
                 out += ", "
@@ -183,8 +191,20 @@ class Timespans:
         assert self.spans, "Cannot exit without starting a span"
         last_span = self.spans[-1]
         assert len(last_span) == 1, "The latest span was already closed"
-        assert when > last_span[0], "Span cannot end sooner it has started"
+        assert when >= last_span[0], "Span cannot end sooner it has started"
         last_span.append(when)
+
+    @property
+    def filled(self):
+        """Does this timespan have any data"""
+        return True if self.spans else False
+
+    @property
+    def open_ended(self):
+        """Have we the last timespan closed or still going on?"""
+        if not self.spans:
+            return True
+        return len(self.spans[-1]) == 1
 
     @property
     def start(self):


### PR DESCRIPTION
This PR adds support for accounting cycle time in workflow state graphs where there are cycles.

An example is: dev -> code review -> QA -> QA fixes -> code review -> QA 

The PR is initially opened, multiple changes needs to reviewed and tested before this is merge quality. 