### PR TITLE
Reliable field comparison by field ID in iter_changes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-ignore = W503
-max-line-length = 79
+ignore = E501,W503,E302,E241,W293,E128,E124,E123,W504,E261,E111,E226,E126,E127,E203
+# max-line-length = 79
 # max-complexity = 18
 select = B,C,E,F,W,T4,B9

--- a/jira_agile_metrics/calculator.py
+++ b/jira_agile_metrics/calculator.py
@@ -54,7 +54,7 @@ def run_calculators(calculators, query_manager, settings):
         logger.info("Writing file for %s...", c.__class__.__name__)
         try:
             c.write()
-        except Exception as e:
+        except Exception:
             logger.exception("Writing file for %s failed with a fatal error. Attempting to run subsequent writers regardless.", c.__class__.__name__)
         else:
             logger.info("%s completed\n", c.__class__.__name__)

--- a/jira_agile_metrics/calculators/ageingwip_test.py
+++ b/jira_agile_metrics/calculators/ageingwip_test.py
@@ -80,8 +80,6 @@ def query_manager(minimal_query_manager):
 def results(large_cycle_time_results):
     return extend_dict(large_cycle_time_results, {})
 
-
-
 @pytest.fixture
 def today():
     return datetime.date(2018, 1, 10)

--- a/jira_agile_metrics/calculators/cycletime.py
+++ b/jira_agile_metrics/calculators/cycletime.py
@@ -5,7 +5,7 @@ import dateutil
 import pandas as pd
 
 from ..calculator import Calculator
-from ..utils import get_extension, to_json_string, StatusTypes
+from ..utils import get_extension, to_json_string
 
 logger = logging.getLogger(__name__)
 
@@ -256,7 +256,6 @@ def calculate_cycle_times(
             if committed_timestamp is not None and done_timestamp is not None:
                 item['cycle_time'] = done_timestamp - committed_timestamp
                 item['completed_timestamp'] = done_timestamp
-
 
             for k, v in item.items():
                 series[k]['data'].append(v)

--- a/jira_agile_metrics/calculators/cycletime_test.py
+++ b/jira_agile_metrics/calculators/cycletime_test.py
@@ -40,12 +40,12 @@ def jira(custom_fields):
             customfield_003=Value(None, []),
             customfield_100=None,
             changes=[
-                Change("2018-01-02 10:01:01", [("Flagged", None, "Impediment")]),
-                Change("2018-01-03 01:00:00", [("Flagged", "Impediment", "")]),  # blocked 1 day in the backlog (doesn't count towards blocked days)
-                Change("2018-01-03 01:01:01", [("status", "Backlog", "Next",)]),
-                Change("2018-01-04 10:01:01", [("Flagged", "", "Impediment")]),
-                Change("2018-01-05 08:01:01", [("Flagged", "Impediment", "")]),  # was blocked 1 day
-                Change("2018-01-08 10:01:01", [("Flagged", "", "Impediment")]),  # stays blocked until today
+                Change("2018-01-02 10:01:01", [("Flagged", "customfield_100", None, "Impediment")]),
+                Change("2018-01-03 01:00:00", [("Flagged", "customfield_100", "Impediment", "")]),  # blocked 1 day in the backlog (doesn't count towards blocked days)
+                Change("2018-01-03 01:01:01", [("status", "status", "Backlog", "Next",)]),
+                Change("2018-01-04 10:01:01", [("Flagged", "customfield_100", "", "Impediment")]),
+                Change("2018-01-05 08:01:01", [("Flagged", "customfield_100", "Impediment", "")]),  # was blocked 1 day
+                Change("2018-01-08 10:01:01", [("Flagged", "customfield_100", "", "Impediment")]),  # stays blocked until today
             ],
         ),
         Issue("A-3",
@@ -60,11 +60,11 @@ def jira(custom_fields):
             customfield_003=Value(None, []),
             customfield_100=None,
             changes=[
-                Change("2018-01-03 01:01:01", [("status", "Backlog", "Next",)]),
-                Change("2018-01-04 01:01:01", [("status", "Next", "Build",)]),
-                Change("2018-01-04 10:01:01", [("Flagged", None, "Impediment")]),  # should clear two days later when issue resolved
-                Change("2018-01-05 01:01:01", [("status", "Build", "QA",)]),
-                Change("2018-01-06 01:01:01", [("status", "QA", "Done",)]),
+                Change("2018-01-03 01:01:01", [("status", "status", "Backlog", "Next",)]),
+                Change("2018-01-04 01:01:01", [("status", "status", "Next", "Build",)]),
+                Change("2018-01-04 10:01:01", [("Flagged", "customfield_100", None, "Impediment")]),  # should clear two days later when issue resolved
+                Change("2018-01-05 01:01:01", [("status", "status", "Build", "QA",)]),
+                Change("2018-01-06 01:01:01", [("status", "status", "QA", "Done",)]),
             ],
         ),
         Issue("A-4",
@@ -79,11 +79,11 @@ def jira(custom_fields):
             customfield_003=Value(None, []),
             customfield_100=None,
             changes=[
-                Change("2018-01-04 01:01:01", [("status", "Backlog", "Next",)]),
-                Change("2018-01-05 01:01:01", [("status", "Next", "Build",)]),
-                Change("2018-01-06 01:01:01", [("status", "Build", "Next",)]),
-                Change("2018-01-07 01:01:01", [("Flagged", None, "Awaiting input")]),
-                Change("2018-01-10 10:01:01", [("Flagged", "Awaiting input", "")]),  # blocked 3 days
+                Change("2018-01-04 01:01:01", [("status", "status", "Backlog", "Next",)]),
+                Change("2018-01-05 01:01:01", [("status", "status", "Next", "Build",)]),
+                Change("2018-01-06 01:01:01", [("status", "status", "Build", "Next",)]),
+                Change("2018-01-07 01:01:01", [("Flagged", "customfield_100", None, "Awaiting input")]),
+                Change("2018-01-10 10:01:01", [("Flagged", "customfield_100", "Awaiting input", "")]),  # blocked 3 days
             ],
         ),
     ])
@@ -103,8 +103,8 @@ def jira_with_skipped_columns(custom_fields):
             customfield_003=Value(None, []),
             customfield_100=None,
             changes=[
-                Change("2018-01-02 01:05:01", [("status", "Backlog", "Next",)]),
-                Change("2018-01-04 01:01:01", [("status", "Next", "Done",), ("resolution", None, "done")]), # skipping columns Build and Test
+                Change("2018-01-02 01:05:01", [("status", "status", "Backlog", "Next",)]),
+                Change("2018-01-04 01:01:01", [("status", "status", "Next", "Done",), ("resolution", "resolution", None, "done")]), # skipping columns Build and Test
             ],
         ),
         Issue("A-11",
@@ -119,8 +119,8 @@ def jira_with_skipped_columns(custom_fields):
             customfield_003=Value(None, []),
             customfield_100=None,
             changes=[
-                Change("2018-01-02 01:05:01", [("status", "Backlog", "Build",)]),
-                Change("2018-01-04 01:01:01", [("status", "Build", "Done",), ("resolution", None, "done")]), # skipping columns Build and Test
+                Change("2018-01-02 01:05:01", [("status", "status", "Backlog", "Build",)]),
+                Change("2018-01-04 01:01:01", [("status", "status", "Build", "Done",), ("resolution", "resolution", None, "done")]), # skipping columns Build and Test
             ],
         ),
     ])

--- a/jira_agile_metrics/calculators/cycletime_test.py
+++ b/jira_agile_metrics/calculators/cycletime_test.py
@@ -323,4 +323,3 @@ def test_movement_skipped_columns(jira_with_skipped_columns, settings):
         'Test': Timestamp('2018-01-04 00:00:00'),
         'Done': Timestamp('2018-01-04 00:00:00'),
     }]
-

--- a/jira_agile_metrics/calculators/cycletime_test.py
+++ b/jira_agile_metrics/calculators/cycletime_test.py
@@ -40,12 +40,12 @@ def jira(custom_fields):
             customfield_003=Value(None, []),
             customfield_100=None,
             changes=[
-                Change("2018-01-02 10:01:01", [("Flagged", "customfield_100", None, "Impediment")]),
-                Change("2018-01-03 01:00:00", [("Flagged", "customfield_100", "Impediment", "")]),  # blocked 1 day in the backlog (doesn't count towards blocked days)
-                Change("2018-01-03 01:01:01", [("status", "status", "Backlog", "Next",)]),
-                Change("2018-01-04 10:01:01", [("Flagged", "customfield_100", "", "Impediment")]),
-                Change("2018-01-05 08:01:01", [("Flagged", "customfield_100", "Impediment", "")]),  # was blocked 1 day
-                Change("2018-01-08 10:01:01", [("Flagged", "customfield_100", "", "Impediment")]),  # stays blocked until today
+                Change("2018-01-02 10:01:01", [("Flagged", None, "Impediment", "customfield_100")]),
+                Change("2018-01-03 01:00:00", [("Flagged", "Impediment", "", "customfield_100")]),  # blocked 1 day in the backlog (doesn't count towards blocked days)
+                Change("2018-01-03 01:01:01", [("status", "Backlog", "Next",)]),
+                Change("2018-01-04 10:01:01", [("Flagged", "", "Impediment", "customfield_100")]),
+                Change("2018-01-05 08:01:01", [("Flagged", "Impediment", "", "customfield_100")]),  # was blocked 1 day
+                Change("2018-01-08 10:01:01", [("Flagged", "", "Impediment", "customfield_100")]),  # stays blocked until today
             ],
         ),
         Issue("A-3",
@@ -60,11 +60,11 @@ def jira(custom_fields):
             customfield_003=Value(None, []),
             customfield_100=None,
             changes=[
-                Change("2018-01-03 01:01:01", [("status", "status", "Backlog", "Next",)]),
-                Change("2018-01-04 01:01:01", [("status", "status", "Next", "Build",)]),
-                Change("2018-01-04 10:01:01", [("Flagged", "customfield_100", None, "Impediment")]),  # should clear two days later when issue resolved
-                Change("2018-01-05 01:01:01", [("status", "status", "Build", "QA",)]),
-                Change("2018-01-06 01:01:01", [("status", "status", "QA", "Done",)]),
+                Change("2018-01-03 01:01:01", [("status", "Backlog", "Next",)]),
+                Change("2018-01-04 01:01:01", [("status", "Next", "Build",)]),
+                Change("2018-01-04 10:01:01", [("Flagged", None, "Impediment", "customfield_100")]),  # should clear two days later when issue resolved
+                Change("2018-01-05 01:01:01", [("status", "Build", "QA",)]),
+                Change("2018-01-06 01:01:01", [("status", "QA", "Done",)]),
             ],
         ),
         Issue("A-4",
@@ -79,11 +79,11 @@ def jira(custom_fields):
             customfield_003=Value(None, []),
             customfield_100=None,
             changes=[
-                Change("2018-01-04 01:01:01", [("status", "status", "Backlog", "Next",)]),
-                Change("2018-01-05 01:01:01", [("status", "status", "Next", "Build",)]),
-                Change("2018-01-06 01:01:01", [("status", "status", "Build", "Next",)]),
-                Change("2018-01-07 01:01:01", [("Flagged", "customfield_100", None, "Awaiting input")]),
-                Change("2018-01-10 10:01:01", [("Flagged", "customfield_100", "Awaiting input", "")]),  # blocked 3 days
+                Change("2018-01-04 01:01:01", [("status", "Backlog", "Next",)]),
+                Change("2018-01-05 01:01:01", [("status", "Next", "Build",)]),
+                Change("2018-01-06 01:01:01", [("status", "Build", "Next",)]),
+                Change("2018-01-07 01:01:01", [("Flagged", None, "Awaiting input", "customfield_100")]),
+                Change("2018-01-10 10:01:01", [("Flagged", "Awaiting input", "", "customfield_100")]),  # blocked 3 days
             ],
         ),
     ])
@@ -103,8 +103,8 @@ def jira_with_skipped_columns(custom_fields):
             customfield_003=Value(None, []),
             customfield_100=None,
             changes=[
-                Change("2018-01-02 01:05:01", [("status", "status", "Backlog", "Next",)]),
-                Change("2018-01-04 01:01:01", [("status", "status", "Next", "Done",), ("resolution", "resolution", None, "done")]), # skipping columns Build and Test
+                Change("2018-01-02 01:05:01", [("status", "Backlog", "Next",)]),
+                Change("2018-01-04 01:01:01", [("status", "Next", "Done",), ("resolution", None, "done")]), # skipping columns Build and Test
             ],
         ),
         Issue("A-11",
@@ -119,8 +119,8 @@ def jira_with_skipped_columns(custom_fields):
             customfield_003=Value(None, []),
             customfield_100=None,
             changes=[
-                Change("2018-01-02 01:05:01", [("status", "status", "Backlog", "Build",)]),
-                Change("2018-01-04 01:01:01", [("status", "status", "Build", "Done",), ("resolution", "resolution", None, "done")]), # skipping columns Build and Test
+                Change("2018-01-02 01:05:01", [("status", "Backlog", "Build",)]),
+                Change("2018-01-04 01:01:01", [("status", "Build", "Done",), ("resolution", None, "done")]), # skipping columns Build and Test
             ],
         ),
     ])

--- a/jira_agile_metrics/calculators/progressreport.py
+++ b/jira_agile_metrics/calculators/progressreport.py
@@ -44,11 +44,11 @@ class ProgressReportCalculator(Calculator):
         # Prepare and validate configuration options
 
         cycle = self.settings['cycle']
-        cycle_names = [s['name'] for s in cycle]
+        # (unused) cycle_names = [s['name'] for s in cycle]
         quantiles = self.settings['quantiles']
 
         backlog_column = self.settings['backlog_column']
-        committed_column = self.settings['committed_column']
+        # (unused) committed_column = self.settings['committed_column']
         done_column = self.settings['done_column']
 
         epic_query_template = self.settings['progress_report_epic_query_template']

--- a/jira_agile_metrics/calculators/progressreport_test.py
+++ b/jira_agile_metrics/calculators/progressreport_test.py
@@ -241,12 +241,12 @@ def query_manager(fields, settings):
                 created="2018-01-02 01:01:01",
                 customfield_205="E-1",
                 changes=[
-                    Change("2018-01-02 10:01:01", [("Flagged", None, "Impediment")]),
-                    Change("2018-01-03 01:00:00", [("Flagged", "Impediment", "")]),  # blocked 1 day in the backlog (doesn't count towards blocked days)
+                    Change("2018-01-02 10:01:01", [("Flagged", None, "Impediment", "customfield_100")]),
+                    Change("2018-01-03 01:00:00", [("Flagged", "Impediment", "", "customfield_100")]),  # blocked 1 day in the backlog (doesn't count towards blocked days)
                     Change("2018-01-03 01:01:01", [("status", "Backlog", "Next",)]),
-                    Change("2018-01-04 10:01:01", [("Flagged", "", "Impediment")]),
-                    Change("2018-01-05 08:01:01", [("Flagged", "Impediment", "")]),  # was blocked 1 day
-                    Change("2018-01-08 10:01:01", [("Flagged", "", "Impediment")]),  # stays blocked until today
+                    Change("2018-01-04 10:01:01", [("Flagged", "", "Impediment", "customfield_100")]),
+                    Change("2018-01-05 08:01:01", [("Flagged", "Impediment", "", "customfield_100")]),  # was blocked 1 day
+                    Change("2018-01-08 10:01:01", [("Flagged", "", "Impediment", "customfield_100")]),  # stays blocked until today
                 ],
             ),
             Issue("A-3",
@@ -260,7 +260,7 @@ def query_manager(fields, settings):
                 changes=[
                     Change("2018-01-03 01:01:01", [("status", "Backlog", "Next",)]),
                     Change("2018-01-04 01:01:01", [("status", "Next", "Build",)]),
-                    Change("2018-01-04 10:01:01", [("Flagged", None, "Impediment")]),  # should clear two days later when issue resolved
+                    Change("2018-01-04 10:01:01", [("Flagged", None, "Impediment", "customfield_100")]),  # should clear two days later when issue resolved
                     Change("2018-01-05 01:01:01", [("status", "Build", "QA",)]),
                     Change("2018-01-06 01:01:01", [("status", "QA", "Done",)]),
                 ],
@@ -277,8 +277,8 @@ def query_manager(fields, settings):
                     Change("2018-01-04 01:01:01", [("status", "Backlog", "Next",)]),
                     Change("2018-01-05 01:01:01", [("status", "Next", "Build",)]),
                     Change("2018-01-06 01:01:01", [("status", "Build", "Next",)]),
-                    Change("2018-01-07 01:01:01", [("Flagged", None, "Awaiting input")]),
-                    Change("2018-01-10 10:01:01", [("Flagged", "Awaiting input", "")]),  # blocked 3 days
+                    Change("2018-01-07 01:01:01", [("Flagged", None, "Awaiting input", "customfield_100")]),
+                    Change("2018-01-10 10:01:01", [("Flagged", "Awaiting input", "", "customfield_100")]),  # blocked 3 days
                 ],
             ),
 

--- a/jira_agile_metrics/calculators/wip.py
+++ b/jira_agile_metrics/calculators/wip.py
@@ -15,7 +15,7 @@ class WIPChartCalculator(Calculator):
 
     def run(self):
         cfd_data = self.get_result(CFDCalculator)
-        cycle_names = [s['name'] for s in self.settings['cycle']]
+        # (unused) cycle_names = [s['name'] for s in self.settings['cycle']]
 
         committed_column = self.settings['committed_column']
         done_column = self.settings['done_column']

--- a/jira_agile_metrics/config.py
+++ b/jira_agile_metrics/config.py
@@ -106,7 +106,7 @@ def to_progress_report_outcomes_list(value):
     } for val in value]
 
 
-def config_to_options(data, cwd=None, extended=False, extended_file_opener=None):
+def config_to_options(data, cwd=None, extended=False):
     try:
         config = ordered_load(data, yaml.SafeLoader)
     except Exception as e:
@@ -261,7 +261,7 @@ def config_to_options(data, cwd=None, extended=False, extended_file_opener=None)
             raise ConfigError("File `%s` referenced in `extends` not found." % extends_filename) from None
 
         logger.debug("Extending file %s" % extends_filename)
-        with open(extends_filename, opener=extended_file_opener) as extends_file:
+        with open(extends_filename, "r") as extends_file:
             options = config_to_options(extends_file.read(), cwd=os.path.dirname(extends_filename), extended=True)
 
     # Parse and validate Connection

--- a/jira_agile_metrics/config.py
+++ b/jira_agile_metrics/config.py
@@ -5,8 +5,6 @@ import os.path
 
 from pydicti import odicti
 
-from .utils import StatusTypes
-
 from .calculators.cycletime import CycleTimeCalculator
 from .calculators.cfd import CFDCalculator
 from .calculators.scatterplot import ScatterplotCalculator
@@ -482,8 +480,8 @@ def config_to_options(data, cwd=None, extended=False):
                 if options['settings']['committed_column'] not in column_names:
                     raise ConfigError("`Committed column` (%s) must exist in `Workflow`: %s" % (options['settings']['committed_column'], column_names))
                 elif column_names.index(options['settings']['committed_column']) > 0:
-                     options['settings']['backlog_column'] = column_names[column_names.index(options['settings']['committed_column'])-1]
-                     logger.info("`Backlog column` automatically set to `%s`", options['settings']['backlog_column'])
+                    options['settings']['backlog_column'] = column_names[column_names.index(options['settings']['committed_column'])-1]
+                    logger.info("`Backlog column` automatically set to `%s`", options['settings']['backlog_column'])
                 else:
                     raise ConfigError("There must be at least 1 column before `Committed column` (%s) in `Workflow`: %s" % (options['settings']['committed_column'], column_names))
         else:

--- a/jira_agile_metrics/config.py
+++ b/jira_agile_metrics/config.py
@@ -106,7 +106,7 @@ def to_progress_report_outcomes_list(value):
     } for val in value]
 
 
-def config_to_options(data, cwd=None, extended=False):
+def config_to_options(data, cwd=None, extended=False, extended_file_opener=None):
     try:
         config = ordered_load(data, yaml.SafeLoader)
     except Exception as e:
@@ -261,7 +261,7 @@ def config_to_options(data, cwd=None, extended=False):
             raise ConfigError("File `%s` referenced in `extends` not found." % extends_filename) from None
 
         logger.debug("Extending file %s" % extends_filename)
-        with open(extends_filename) as extends_file:
+        with open(extends_filename, opener=extended_file_opener) as extends_file:
             options = config_to_options(extends_file.read(), cwd=os.path.dirname(extends_filename), extended=True)
 
     # Parse and validate Connection

--- a/jira_agile_metrics/config_test.py
+++ b/jira_agile_metrics/config_test.py
@@ -563,5 +563,4 @@ Workflow:
 """)
 
     assert options['connection']['domain'] == 'https://foo.com'
-    assert options['connection']['jira_server_version_check'] == False
-
+    assert options['connection']['jira_server_version_check'] is False

--- a/jira_agile_metrics/config_test.py
+++ b/jira_agile_metrics/config_test.py
@@ -9,6 +9,9 @@ from .config import (
     ConfigError
 )
 
+def temp_opener(name, flag, mode=0o777):
+      return os.open(name, flag | os.O_TEMPORARY, mode)
+
 def test_force_list():
     assert force_list(None) == [None]
     assert force_list("foo") == ["foo"]
@@ -424,8 +427,8 @@ Output:
 def test_config_to_options_extends():
     try:
         with tempfile.NamedTemporaryFile(delete=False) as fp:
-            # Base file
-            fp.write(b"""\
+        # Base file
+        fp.write(b"""\
 Connection:
     Domain: https://foo.com
 
@@ -448,11 +451,11 @@ Output:
     Done column: Done
 """)
 
-            fp.seek(0)
+        fp.seek(0)
 
-            # Extend the file
+        # Extend the file
 
-            options = config_to_options("""
+        options = config_to_options("""
 Extends: %s
 
 Connection:
@@ -471,30 +474,30 @@ Output:
         - 0.7
 
     Cycle time data: cycletime.csv
-""" % fp.name, cwd=os.path.abspath(fp.name))
+""" % fp.name, cwd=os.path.abspath(fp.name), extended_file_opener=temp_opener)
     finally:
         os.remove(fp.name)
 
-    # overridden
-    assert options['connection']['domain'] == 'https://bar.com'
+        # overridden
+        assert options['connection']['domain'] == 'https://bar.com'
 
-    # from extended base
-    assert options['settings']['backlog_column'] == 'Backlog'
-    assert options['settings']['committed_column'] == 'In progress'
-    assert options['settings']['done_column'] == 'Done'
+        # from extended base
+        assert options['settings']['backlog_column'] == 'Backlog'
+        assert options['settings']['committed_column'] == 'In progress'
+        assert options['settings']['done_column'] == 'Done'
 
-    # from extending file
-    assert options['settings']['cycle_time_data'] == ['cycletime.csv']
+        # from extending file
+        assert options['settings']['cycle_time_data'] == ['cycletime.csv']
 
-    # overridden
-    assert options['settings']['quantiles'] == [0.5, 0.7]
+        # overridden
+        assert options['settings']['quantiles'] == [0.5, 0.7]
 
-    # merged
-    assert options['settings']['attributes'] == {
-        'Release': 'Release number',
-        'Priority': 'Severity',
-        'Team': 'Assigned team'
-    }
+        # merged
+        assert options['settings']['attributes'] == {
+            'Release': 'Release number',
+            'Priority': 'Severity',
+            'Team': 'Assigned team'
+        }
 
 def test_config_to_options_extends_blocked_if_no_explicit_working_directory():
 

--- a/jira_agile_metrics/config_test.py
+++ b/jira_agile_metrics/config_test.py
@@ -9,9 +9,6 @@ from .config import (
     ConfigError
 )
 
-def temp_opener(name, flag, mode=0o777):
-      return os.open(name, flag | os.O_TEMPORARY, mode)
-
 def test_force_list():
     assert force_list(None) == [None]
     assert force_list("foo") == ["foo"]
@@ -427,8 +424,8 @@ Output:
 def test_config_to_options_extends():
     try:
         with tempfile.NamedTemporaryFile(delete=False) as fp:
-        # Base file
-        fp.write(b"""\
+            # Base file
+            fp.write(b"""\
 Connection:
     Domain: https://foo.com
 
@@ -451,11 +448,11 @@ Output:
     Done column: Done
 """)
 
-        fp.seek(0)
+            fp.close()
 
-        # Extend the file
+            # Extend the file
 
-        options = config_to_options("""
+            options = config_to_options("""
 Extends: %s
 
 Connection:
@@ -474,30 +471,30 @@ Output:
         - 0.7
 
     Cycle time data: cycletime.csv
-""" % fp.name, cwd=os.path.abspath(fp.name), extended_file_opener=temp_opener)
+""" % fp.name, cwd=os.path.abspath(fp.name))
     finally:
         os.remove(fp.name)
 
-        # overridden
-        assert options['connection']['domain'] == 'https://bar.com'
+    # overridden
+    assert options['connection']['domain'] == 'https://bar.com'
 
-        # from extended base
-        assert options['settings']['backlog_column'] == 'Backlog'
-        assert options['settings']['committed_column'] == 'In progress'
-        assert options['settings']['done_column'] == 'Done'
+    # from extended base
+    assert options['settings']['backlog_column'] == 'Backlog'
+    assert options['settings']['committed_column'] == 'In progress'
+    assert options['settings']['done_column'] == 'Done'
 
-        # from extending file
-        assert options['settings']['cycle_time_data'] == ['cycletime.csv']
+    # from extending file
+    assert options['settings']['cycle_time_data'] == ['cycletime.csv']
 
-        # overridden
-        assert options['settings']['quantiles'] == [0.5, 0.7]
+    # overridden
+    assert options['settings']['quantiles'] == [0.5, 0.7]
 
-        # merged
-        assert options['settings']['attributes'] == {
-            'Release': 'Release number',
-            'Priority': 'Severity',
-            'Team': 'Assigned team'
-        }
+    # merged
+    assert options['settings']['attributes'] == {
+        'Release': 'Release number',
+        'Priority': 'Severity',
+        'Team': 'Assigned team'
+    }
 
 def test_config_to_options_extends_blocked_if_no_explicit_working_directory():
 

--- a/jira_agile_metrics/conftest.py
+++ b/jira_agile_metrics/conftest.py
@@ -25,8 +25,9 @@ class FauxFields(object):
 class FauxChangeItem(object):
     """An item in a changelog change
     """
-    def __init__(self, field, fromString, toString):
+    def __init__(self, field, fieldId, fromString, toString):
         self.field = field
+        self.fieldId = fieldId
         self.from_ = self.fromString = fromString
         self.to = self.toString = toString
 

--- a/jira_agile_metrics/conftest.py
+++ b/jira_agile_metrics/conftest.py
@@ -25,9 +25,9 @@ class FauxFields(object):
 class FauxChangeItem(object):
     """An item in a changelog change
     """
-    def __init__(self, field, fieldId, fromString, toString):
+    def __init__(self, field, fromString, toString, fieldId=None):
         self.field = field
-        self.fieldId = fieldId
+        self.fieldId = fieldId if fieldId is not None else field
         self.from_ = self.fromString = fromString
         self.to = self.toString = toString
 

--- a/jira_agile_metrics/querymanager.py
+++ b/jira_agile_metrics/querymanager.py
@@ -172,7 +172,7 @@ class QueryManager(object):
             for item in change.items:
                 if _field_id_from_changelog_item(item) in field_ids_to_names:
                     yield IssueSnapshot(
-                        change=field_ids_to_names[item.fieldId],
+                        change=field_ids_to_names[_field_id_from_changelog_item(item)],
                         key=issue.key,
                         date=change_date,
                         from_string=item.fromString,

--- a/jira_agile_metrics/querymanager.py
+++ b/jira_agile_metrics/querymanager.py
@@ -8,6 +8,12 @@ from .config import ConfigError
 
 logger = logging.getLogger(__name__)
 
+def _field_id_from_changelog_item(history_item):
+    if hasattr(history_item, 'fieldId'):
+        return history_item.fieldId
+    else:
+        return history_item.field
+
 class IssueSnapshot(object):
     """A snapshot of the key fields of an issue at a point in its change history
     """
@@ -132,12 +138,20 @@ class QueryManager(object):
         initial value. `fields` is a list of fields to monitor, e.g.
         `['status']`.
         """
+        
+        # Since the changelog history lists field ids and not names, we
+        # need to pre-cache the field ids of the fields to watch in the
+        # changelog
+        field_ids_to_names = {}
 
         for field in fields:
-            initial_value = self.resolve_field_value(issue, self.field_name_to_id(field))
+            field_id = self.field_name_to_id(field)
+            field_ids_to_names[field_id] = field
+            
+            initial_value = self.resolve_field_value(issue, field_id)
             try:
                 initial_value = next(filter(
-                    lambda h: h.field == field,
+                    lambda h: _field_id_from_changelog_item(h) == field_id,
                     itertools.chain.from_iterable([c.items for c in sorted(
                         issue.changelog.histories, key=lambda c: dateutil.parser.parse(c.created))])
                 )).fromString
@@ -156,9 +170,9 @@ class QueryManager(object):
             change_date = dateutil.parser.parse(change.created, ignoretz=True)
 
             for item in change.items:
-                if item.field in fields:
+                if _field_id_from_changelog_item(item) in field_ids_to_names:
                     yield IssueSnapshot(
-                        change=item.field,
+                        change=field_ids_to_names[item.fieldId],
                         key=issue.key,
                         date=change_date,
                         from_string=item.fromString,

--- a/jira_agile_metrics/querymanager_test.py
+++ b/jira_agile_metrics/querymanager_test.py
@@ -17,7 +17,7 @@ def jira(custom_fields):
         Issue("A-1",
             summary="Issue A-1",
             issuetype=Value("Story", "story"),
-            status=Value("Backlotg", "backlog"),
+            status=Value("Backlog", "backlog"),
             resolution=None,
             created="2018-01-01 01:01:01",
             customfield_001="Team 1",
@@ -27,10 +27,10 @@ def jira(custom_fields):
                 # the changes are not in chrnological order, the first change is intentionally the third 
                 # status change. This is intended to test that we manage get the correct first status change as
                 # the transition from Backlog to Next
-                Change("2018-01-03 01:01:01", [("resolution", "resolution", None, "Closed",), ("status", "status", "Next", "Done",)]),
-                Change("2018-01-02 01:01:01", [("status", "status", "Backlog", "Next",)]),
-                Change("2018-01-02 01:01:01", [("Team", "customfield_001", "Team 2", "Team 1",)]),
-                Change("2018-01-04 01:01:01", [("resolution", "resolution", "Closed", None,), ("status", "status", "Done", "QA",)]),
+                Change("2018-01-03 01:01:01", [("resolution", "resolution", None, "Closed",), ("status", "Next", "Done",)]),
+                Change("2018-01-02 01:01:01", [("status", "Backlog", "Next",)]),
+                Change("2018-01-02 01:01:01", [("Team", "Team 2", "Team 1", "customfield_001")]),
+                Change("2018-01-04 01:01:01", [("resolution", "Closed", None,), ("status", "Done", "QA",)]),
             ],
         )
     ])

--- a/jira_agile_metrics/querymanager_test.py
+++ b/jira_agile_metrics/querymanager_test.py
@@ -27,10 +27,10 @@ def jira(custom_fields):
                 # the changes are not in chrnological order, the first change is intentionally the third 
                 # status change. This is intended to test that we manage get the correct first status change as
                 # the transition from Backlog to Next
-                Change("2018-01-03 01:01:01", [("resolution", None, "Closed",), ("status", "Next", "Done",)]),
-                Change("2018-01-02 01:01:01", [("status", "Backlog", "Next",)]),
-                Change("2018-01-02 01:01:01", [("Team", "Team 2", "Team 1",)]),
-                Change("2018-01-04 01:01:01", [("resolution", "Closed", None,), ("status", "Done", "QA",)]),
+                Change("2018-01-03 01:01:01", [("resolution", "resolution", None, "Closed",), ("status", "status", "Next", "Done",)]),
+                Change("2018-01-02 01:01:01", [("status", "status", "Backlog", "Next",)]),
+                Change("2018-01-02 01:01:01", [("Team", "customfield_001", "Team 2", "Team 1",)]),
+                Change("2018-01-04 01:01:01", [("resolution", "resolution", "Closed", None,), ("status", "status", "Done", "QA",)]),
             ],
         )
     ])

--- a/jira_agile_metrics/querymanager_test.py
+++ b/jira_agile_metrics/querymanager_test.py
@@ -24,7 +24,7 @@ def jira(custom_fields):
             customfield_002=Value(None, 30),
             customfield_003=Value(None, ["R2", "R3", "R4"]),
             changes=[
-                # the changes are not in chrnological order, the first change is intentionally the third 
+                # the changes are not in chrnological order, the first change is intentionally the third
                 # status change. This is intended to test that we manage get the correct first status change as
                 # the transition from Backlog to Next
                 Change("2018-01-03 01:01:01", [("resolution", "resolution", None, "Closed",), ("status", "Next", "Done",)]),


### PR DESCRIPTION
This suggested pull request addresses an issue where changes in certain fields were skipped by `querymanager.iter_changes` because field references in an issue change log are field IDs, and not human-readable field names.

The change also takes into account the situation where change log entries for certain fields do not include the `fieldId` attribute but only the `field` attribute (that contains the field ID in such a case)