### PR TITLE
Fix progress report throughput fatal error

### DIFF
--- a/jira_agile_metrics/calculators/progressreport.py
+++ b/jira_agile_metrics/calculators/progressreport.py
@@ -1047,7 +1047,7 @@ def plot_throughput(cycle_data, date_format, frequency="1W"):
             continue
         ax.annotate(
             "%.0f" % y,
-            xy=(x.toordinal(), y + 0.2),
+            xy=(x, y + 0.2),
             ha="center",
             va="bottom",
             fontsize="x-small",


### PR DESCRIPTION
Similar to this [fix](https://github.com/DeloitteDigitalUK/jira-agile-metrics/pull/44), this will make sure that the progress report (with calculated throughput) will run successfully with the docker container.

The fixed issue looked like
```
❯ docker run -it --rm -v $PWD:/data agile-metrics-fix:latest engineering_delivery.yaml
[2021-01-13 14:43:43 WARNING] No `Query` value or `Queries` section found. Many calculators rely on one of these.
[2021-01-13 14:43:57 WARNING] The following JIRA statuses were found, but not mapped to a workflow state, and have been ignored: Deferred / Won't do, Needs Refinement
[2021-01-13 14:44:00 WARNING] The following JIRA statuses were found, but not mapped to a workflow state, and have been ignored: Deferred / Won't do, Needs Refinement
[2021-01-13 14:44:01 WARNING] The following JIRA statuses were found, but not mapped to a workflow state, and have been ignored: Deferred / Won't do, Needs Refinement
[2021-01-13 14:44:03 ERROR] Writing file for ProgressReportCalculator failed with a fatal error. Attempting to run subsequent writers regardless.
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/jira_agile_metrics/calculator.py", line 57, in run_calculators
    c.write()
  File "/usr/local/lib/python3.9/site-packages/jira_agile_metrics/calculators/progressreport.py", line 459, in write
    team_charts={
  File "/usr/local/lib/python3.9/site-packages/jira_agile_metrics/calculators/progressreport.py", line 467, in <dictcomp>
    "throughput": plot_throughput(
  File "/usr/local/lib/python3.9/site-packages/jira_agile_metrics/calculators/progressreport.py", line 1065, in plot_throughput
    fig.savefig(buffer, format="png", bbox_inches="tight", dpi=220)
  File "/usr/local/lib/python3.9/site-packages/matplotlib/figure.py", line 2311, in savefig
    self.canvas.print_figure(fname, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/matplotlib/backend_bases.py", line 2210, in print_figure
    result = print_method(
  File "/usr/local/lib/python3.9/site-packages/matplotlib/backend_bases.py", line 1639, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/matplotlib/backends/backend_agg.py", line 509, in print_png
    FigureCanvasAgg.draw(self)
  File "/usr/local/lib/python3.9/site-packages/matplotlib/backends/backend_agg.py", line 402, in draw
    self.renderer = self.get_renderer(cleared=True)
  File "/usr/local/lib/python3.9/site-packages/matplotlib/backends/backend_agg.py", line 418, in get_renderer
    self.renderer = RendererAgg(w, h, self.figure.dpi)
  File "/usr/local/lib/python3.9/site-packages/matplotlib/backends/backend_agg.py", line 96, in __init__
    self._renderer = _RendererAgg(int(width), int(height), dpi)
ValueError: Image size of 3515551x1062 pixels is too large. It must be less than 2^16 in each direction.
```