### PR TITLE
Added fixed version for pandas

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pyjwt
 requests-oauthlib>=1.2.0
 jira
 PyYAML
-pandas>=0.23.0
+pandas>=0.23.0,<2.0.0
 numpy
 seaborn
 matplotlib


### PR DESCRIPTION
Quick fix for issue #57 to hardcode the version range for pandas to the breaking changes released in v2+ of pandas.

Tests passed locally and fixed our issue of being unable to produce charts/outputs.

![Screenshot 2023-06-21 at 11 49 56](https://github.com/DeloitteDigitalUK/jira-agile-metrics/assets/16841586/242185a7-0c1d-415d-9132-dd007645116b)
