### PR TITLE
Restrict numpy version to < 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ requests-oauthlib>=1.2.0
 jira
 PyYAML
 pandas>=0.23.0,<2.0.0
-numpy
+numpy<2.0.0
 seaborn
 matplotlib
 statsmodels


### PR DESCRIPTION
numpy versions >= 2.0.0 are not compatible with the version of pandas that's used.